### PR TITLE
docs: documentation refresh (overhaul phase 1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,121 @@
+# ui-x Overhaul Roadmap
+
+> Tracking document for bringing ui-x up to date with the modern shadcn ecosystem.
+> Philosophy is unchanged: **additional** accessible, customizable components that
+> complement (not fork) shadcn/ui — focused on form-heavy and data-entry components
+> shadcn doesn't ship.
+
+## Branch strategy
+
+Overhaul work happens on feature branches (`docs/…`, `feat/…`) merged into the
+long-running **`next`** integration branch via PRs. `next` merges into `main`
+only once the overhaul is finalized.
+
+## Guiding decisions
+
+- **v3 is frozen.** `apps/v3` (Tailwind v3) receives no new content. It gets a
+  banner — "You are viewing docs for Tailwind v3. Switch to latest →" — and the
+  Tailwind v4 site becomes canonical at `ui-x.junwen-k.dev`.
+- **Mirror shadcn's library support**: offer both Radix UI and Base UI variants,
+  matching `npx shadcn create` (Base UI is shadcn's default since July 2026).
+- **Own the niche, acknowledge the overlap.** Components that shadcn has since
+  added (Kbd, Button Group, Input Group, Combobox, …) get an honest callout and
+  a recommendation, rather than silently competing.
+
+---
+
+## Phase 0 — Housekeeping (unblocks everything)
+
+- [x] Decide fate of WIP `location-input`: **abandoned** (2026-07-09) — stale,
+      untracked files deleted. May revisit from scratch in Phase 5.
+- [ ] Upgrade `shadcn` CLI from `2.4.0-canary.13` to v3.x; verify
+      `pnpm build:registry` still produces a valid registry.
+- [ ] Dependency pass on `apps/v4`: zod (pinned at 3.21.4), lucide-react,
+      react-day-picker, radix packages, tailwindcss.
+- [ ] Confirm both sites still build and deploy (`turbo build`).
+
+## Phase 1 — Documentation up to date (user-visible, low risk)
+
+- [x] Add v3 "you are viewing old docs" banner in `apps/v3` linking to the v4
+      site (keep the existing `version-dropdown-menu` as secondary navigation).
+- [ ] Point canonical domain / SEO (sitemap, robots, `metadataBase`, og) at the
+      v4 site; v3 moves to a `v3.` subdomain or subpath.
+- [x] Update `installation.mdx` with registry install instructions and
+      requirements (`index.mdx` / `tailwind-v4.mdx` reviewed, still accurate).
+- [ ] Refresh `changelog.mdx` — deferred: write a single entry once the
+      overhaul actually ships, not piecemeal.
+- [x] Clear stale "New" labels in `src/config/docs.ts`.
+- [x] **Overlap callouts** added to kbd, control-group, input-base, combobox —
+      placed above the preview, recommending the official shadcn/ui version;
+      ui-x's is "provided as-is" (calendar and native-select still need a diff
+      vs shadcn's versions — tracked in the audit table below).
+
+### Component overlap audit
+
+| ui-x component | shadcn equivalent (date added) | Action |
+| --- | --- | --- |
+| `kbd` | Kbd (Oct 2025) | ✅ Callout: recommend official, ours as-is |
+| `control-group` | Button Group (Oct 2025) | ✅ Callout: recommend official, ours as-is |
+| `input-base` | Input Group (Oct 2025) | ✅ Callout: recommend official, ours as-is |
+| `combobox` / `combobox-primitive` | Combobox (built on Base UI's primitive, even in the Radix flavor) | ✅ Callouts on both pages: recommend official, ours as-is |
+| `calendar` | Calendar upgrade (Jun 2025) | Diff ours vs theirs; possibly rebase on theirs |
+| `native-select` | Field/Select ecosystem | Verify overlap; callout if needed |
+| date/time fields, phone-input, dropzone, file-list, confirmer, timeline, description-list, wheel-picker, badge-group, emoji-picker, sortable, virtualizer, time | none | Still differentiated — highlight these |
+
+## Phase 2 — Registry modernization (decides architecture for Phases 3–4)
+
+- [ ] Evaluate distribution options and pick one:
+      - [ ] Namespaced registry (`npx shadcn add @ui-x/date-field`)
+      - [ ] GitHub-repo-as-registry (https://ui.shadcn.com/docs/registry/github)
+      - [ ] Keep current self-hosted registry.json, upgraded to CLI v3 schema
+- [ ] Decide registry layout for dual-library support (how shadcn structures
+      Radix vs Base UI items — mirror it) and for style variants (new-york,
+      Luma, Rhea?).
+- [ ] Universal registry items where applicable (hooks, utilities).
+- [ ] Consider exposing the registry via MCP server.
+- [ ] Evaluate migrating the v4 docs site from velite to fumadocs (shadcn's
+      current setup) — decide before writing large amounts of new MDX content
+      so it only gets authored once.
+
+## Phase 3 — Component styling refresh
+
+- [ ] Update all ui-x components to match latest shadcn conventions:
+      `data-slot` attributes, current sizing/spacing, tw-animate-css idioms,
+      current `new-york` output of the v3 CLI.
+- [ ] Re-sync the vendored shadcn `ui/` components in `apps/v4` used by the
+      docs site itself.
+- [ ] Verify every demo/example still renders correctly after restyle.
+
+## Phase 4 — Base UI + Radix dual support
+
+- [ ] Port each ui-x component to Base UI primitives alongside the Radix
+      version (start with the differentiated set: date/time fields,
+      phone-input, dropzone, confirmer, …).
+- [ ] Docs: per-component library switcher or install-command tabs
+      (Radix / Base UI), mirroring shadcn's docs UX.
+- [ ] Update demos/examples for both variants.
+
+## Phase 5 — New components & catch-up (stretch)
+
+- [ ] Revisit `location-input` (Google Places) from Phase 0.
+- [ ] Survey what's newly worth building that shadcn still lacks
+      (chat components arrived Jun 2026 — avoid; form/data-entry gaps — pursue).
+
+---
+
+## Open questions
+
+- Deprecation policy — **partially decided (2026-07-09)**: overlapped
+  components stay published but are "provided as-is" with a prominent callout
+  recommending the official shadcn/ui version. Still open: whether they are
+  ever removed from the registry, and whether they get styling refreshes in
+  Phase 3.
+- Do we adopt shadcn's newer styles (Luma/Rhea) or stay `new-york`-only?
+- Monorepo: `packages/` is empty — flatten, or reserve for shared registry
+  tooling in Phase 2?
+
+## Status log
+
+- **2026-07-09** — Roadmap created. Current state: v4 site has 34 registry
+  items; last feature work Jun 2025; shadcn has since shipped CLI v3, MCP,
+  Base UI default, GitHub registries, and 7+ overlapping components.

--- a/apps/v3/src/app/(app)/layout.tsx
+++ b/apps/v3/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { SiteMain } from "@/components/site-main"
+import { VersionBanner } from "@/components/version-banner"
 
 interface AppLayoutProps {
   children: React.ReactNode
@@ -9,6 +10,7 @@ interface AppLayoutProps {
 export default function AppLayout({ children }: AppLayoutProps) {
   return (
     <>
+      <VersionBanner />
       <SiteHeader />
       <SiteMain>{children}</SiteMain>
       <SiteFooter />

--- a/apps/v3/src/components/version-banner.tsx
+++ b/apps/v3/src/components/version-banner.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link"
+import { ArrowRightIcon } from "lucide-react"
+
+export function VersionBanner() {
+  return (
+    <div className="group bg-primary px-4 py-1.5 text-primary-foreground">
+      <Link
+        href={process.env.NEXT_PUBLIC_APP_URL_V4!}
+        className="flex items-center justify-center gap-1 text-center text-sm font-medium"
+      >
+        You are viewing the docs for Tailwind CSS v3. Switch to latest
+        <ArrowRightIcon className="size-4 transition-transform group-hover:translate-x-0.5" />
+      </Link>
+    </div>
+  )
+}

--- a/apps/v4/src/config/docs.ts
+++ b/apps/v4/src/config/docs.ts
@@ -79,7 +79,6 @@ export const docsConfig = {
         {
           title: "Phone Input",
           href: "/docs/primitives/phone-input",
-          label: "New",
           items: [],
         },
       ],
@@ -155,7 +154,6 @@ export const docsConfig = {
         {
           title: "Emoji Picker",
           href: "/docs/components/emoji-picker",
-          label: "New",
           items: [],
         },
         {
@@ -196,7 +194,6 @@ export const docsConfig = {
         {
           title: "Phone Input",
           href: "/docs/components/phone-input",
-          label: "New",
           items: [],
         },
         {
@@ -217,7 +214,6 @@ export const docsConfig = {
         {
           title: "Wheel Picker",
           href: "/docs/components/wheel-picker",
-          label: "New",
           items: [],
         },
       ],

--- a/apps/v4/src/content/docs/components/combobox.mdx
+++ b/apps/v4/src/content/docs/components/combobox.mdx
@@ -5,6 +5,12 @@ links:
   doc: /docs/primitives/combobox
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: shadcn/ui now includes its own [Combobox](https://ui.shadcn.com/docs/components/combobox) component, built on Base UI's Combobox primitive. We recommend using the official version — this component predates it and is provided as-is.
+
+</Callout>
+
 <ComponentPreview
   name="combobox-demo"
   className="[&_div[cmdk-root]]:max-w-xs"

--- a/apps/v4/src/content/docs/components/control-group.mdx
+++ b/apps/v4/src/content/docs/components/control-group.mdx
@@ -3,6 +3,12 @@ title: Control Group
 description: A component for grouping form controls like text inputs, buttons, selects and other elements into a single cohesive unit.
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: shadcn/ui now includes a [Button Group](https://ui.shadcn.com/docs/components/button-group) component, added in October 2025, which covers most of the same use cases. We recommend using the official version — this component predates it and is provided as-is.
+
+</Callout>
+
 <ComponentPreview name="control-group-demo" />
 
 ## Installation

--- a/apps/v4/src/content/docs/components/input-base.mdx
+++ b/apps/v4/src/content/docs/components/input-base.mdx
@@ -3,6 +3,12 @@ title: Input Base
 description: Base component to create custom inputs.
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: shadcn/ui now includes an [Input Group](https://ui.shadcn.com/docs/components/input-group) component, added in October 2025, for decorating inputs with icons, buttons and text. For that use case we recommend the official version — this component predates it and is provided as-is. Input Base still serves as the foundation for other ui-x components such as [Combobox](/docs/components/combobox) and the date/time fields.
+
+</Callout>
+
 <ComponentPreview name="input-base-demo" />
 
 ## Installation

--- a/apps/v4/src/content/docs/components/kbd.mdx
+++ b/apps/v4/src/content/docs/components/kbd.mdx
@@ -3,6 +3,12 @@ title: Kbd
 description: Displays which key or combination of keys performs a given action.
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: shadcn/ui now includes its own [Kbd](https://ui.shadcn.com/docs/components/kbd) component, added in October 2025. We recommend using the official version — this component predates it and is provided as-is.
+
+</Callout>
+
 <ComponentPreview name="kbd-demo" />
 
 ## Installation

--- a/apps/v4/src/content/docs/installation.mdx
+++ b/apps/v4/src/content/docs/installation.mdx
@@ -3,4 +3,23 @@ title: Installation
 description: How to install dependencies and structure your app.
 ---
 
-For installation instructions and setting up dependencies, please refer to the official Shadcn [installation guide](https://ui.shadcn.com/docs/installation). This guide provides the most up-to-date information for structuring your app and ensuring compatibility.
+junwen-k/ui-x is an extension of [shadcn/ui](https://ui.shadcn.com) and is distributed through the same registry system. Set up shadcn/ui in your project first by following the official [installation guide](https://ui.shadcn.com/docs/installation) for your framework.
+
+## Requirements
+
+- A project set up with [shadcn/ui](https://ui.shadcn.com/docs/installation) (Tailwind CSS v4 and React 19 for the latest components — see the [Tailwind v3 docs](https://v3-ui-x.junwen-k.dev) if you are still on v3).
+- Components are currently built on [Radix UI](https://www.radix-ui.com) primitives, matching shadcn/ui's Radix-based components.
+
+## Installing components
+
+Every component can be installed with the shadcn CLI by pointing at this registry:
+
+```bash
+npx shadcn@latest add https://ui-x.junwen-k.dev/r/date-field.json
+```
+
+Each component's documentation page includes its exact install command, along with a manual installation option if you prefer to copy the source directly.
+
+## Utilities
+
+Utility docs such as [Sortable](/docs/utilities/sortable) and [Virtualizer](/docs/utilities/virtualizer) are guides built around third-party libraries — their pages describe which packages to install.

--- a/apps/v4/src/content/docs/primitives/combobox.mdx
+++ b/apps/v4/src/content/docs/primitives/combobox.mdx
@@ -6,6 +6,12 @@ links:
   doc: https://cmdk.paco.me
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: [Base UI](https://base-ui.com/react/components/combobox) now ships a native Combobox primitive, which shadcn/ui's official [Combobox](https://ui.shadcn.com/docs/components/combobox) is built on. We recommend using those — this primitive predates them and is provided as-is.
+
+</Callout>
+
 <ComponentPreview name="combobox-primitive-demo" />
 
 ## About


### PR DESCRIPTION
## Summary

First batch of the [overhaul roadmap](https://github.com/junwen-k/ui-x/blob/docs/overhaul-phase-1/ROADMAP.md) (Phase 1 — documentation up to date):

- **ROADMAP.md** — tracks the full overhaul: docs refresh, registry modernization, styling refresh, Base UI support. Feature branches merge into `next`; `next` merges into `main` once the overhaul is finalized.
- **v3 site frozen** — a banner above the header ("You are viewing the docs for Tailwind CSS v3. Switch to latest →") links to the v4 docs. Kept out of the `(blocks)` route group since those render in preview iframes.
- **Installation guide** — now documents the registry install flow (`npx shadcn@latest add https://ui-x.junwen-k.dev/r/<name>.json`) and requirements instead of only deferring to shadcn/ui.
- **Overlap callouts** — Kbd, Control Group, Input Base and Combobox (component + primitive pages) predate their shadcn/ui equivalents (Kbd, Button Group, Input Group, Combobox — Oct 2025 onwards). Each page now leads with a prominent callout recommending the official version; ui-x's remain provided as-is.
- Removed year-old "New" sidebar labels; abandoned the stale WIP location-input files.

## Test plan

- [x] v3 dev server: banner renders on `/docs`, links to the v4 URL from env
- [x] v4 dev server: all edited pages return 200; callouts render above the component previews; velite compiles with no MDX errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)