### PR TITLE
fix(v4): add nativeButton={false} to link-rendered buttons

### DIFF
--- a/apps/v4/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/v4/src/app/docs/[[...slug]]/page.tsx
@@ -56,6 +56,7 @@ export default async function Page({ params }: DocPageProps) {
                       variant="secondary"
                       size="icon"
                       className="extend-touch-target size-8 shadow-none md:size-7"
+                      nativeButton={false}
                       render={
                         <Link href={neighbours.previous.url}>
                           <ArrowLeftIcon />
@@ -69,6 +70,7 @@ export default async function Page({ params }: DocPageProps) {
                       variant="secondary"
                       size="icon"
                       className="extend-touch-target size-8 shadow-none md:size-7"
+                      nativeButton={false}
                       render={
                         <Link href={neighbours.next.url}>
                           <span className="sr-only">Next</span>
@@ -127,6 +129,7 @@ export default async function Page({ params }: DocPageProps) {
                 variant="secondary"
                 size="sm"
                 className="shadow-none"
+                nativeButton={false}
                 render={
                   <Link href={neighbours.previous.url}>
                     <ArrowLeftIcon /> {neighbours.previous.name}
@@ -139,6 +142,7 @@ export default async function Page({ params }: DocPageProps) {
                 variant="secondary"
                 size="sm"
                 className="ml-auto shadow-none"
+                nativeButton={false}
                 render={
                   <Link href={neighbours.next.url}>
                     {neighbours.next.name} <ArrowRightIcon />

--- a/apps/v4/src/components/github-link.tsx
+++ b/apps/v4/src/components/github-link.tsx
@@ -12,6 +12,7 @@ export function GitHubLink() {
       size="sm"
       variant="ghost"
       className="h-8 shadow-none"
+      nativeButton={false}
       render={
         <Link href={siteConfig.links.github} target="_blank" rel="noreferrer">
           <Icons.gitHub />

--- a/apps/v4/src/components/main-nav.tsx
+++ b/apps/v4/src/components/main-nav.tsx
@@ -24,6 +24,7 @@ export function MainNav({
           variant="ghost"
           size="sm"
           className="px-2.5"
+          nativeButton={false}
           render={
             <Link
               href={item.href}

--- a/apps/v4/src/components/ui/tabs.tsx
+++ b/apps/v4/src/components/ui/tabs.tsx
@@ -73,7 +73,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
     <TabsPrimitive.Panel
       data-slot="tabs-content"
-      className={cn("min-w-0 flex-1 text-sm outline-none", className)}
+      className={cn("flex-1 text-sm outline-none", className)}
       {...props}
     />
   );

--- a/apps/v4/src/components/ui/tabs.tsx
+++ b/apps/v4/src/components/ui/tabs.tsx
@@ -73,7 +73,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
     <TabsPrimitive.Panel
       data-slot="tabs-content"
-      className={cn("flex-1 text-sm outline-none", className)}
+      className={cn("min-w-0 flex-1 text-sm outline-none", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- Adds `nativeButton={false}` to six Base UI `Button`s that render Next.js `Link`s via the `render` prop — the prev/next doc-nav buttons in `docs/[[...slug]]/page.tsx` (4×), `main-nav.tsx` (1×), and `github-link.tsx` (1×). This follows Base UI's documented custom-link pattern and silences the console warning that produced the "6 Issues" badge in Next.js Dev Tools.
- Reverts the earlier `min-w-0` band-aid on `TabsContent`, so `tabs.tsx` again matches shadcn's `base-nova` upstream byte-for-byte.

## The tabs layout issue was not a source bug

The broken docs layout (CLI/Manual tabs rendering side-by-side, overflowing code blocks) was caused by the Next dev server serving **stale compiled CSS** that predated the `@import "shadcn/tailwind.css"` / `shadcn@4.13.0` bump. That import defines the `data-horizontal`/`data-vertical` custom variants (matching `[data-orientation="..."]`); without them, `data-horizontal:flex-col` compiles to a bare `[data-horizontal]` selector that never matches Base UI's output, so the tabs root never stacked.

Verified via an offline Tailwind compile of the current source (correct selectors + scroll-fade utilities emitted) and by forcing the dev server to recompile — after which the Date Picker and Password Input docs pages render identically to shadcn's, with zero overflowing `<pre>` elements and a clean console. Production builds were never affected.

## Test plan

- [x] Console clean on `/docs/primitives/date-picker` and `/docs/primitives/password-input` (no `nativeButton` warnings, no Dev Tools issue badge)
- [x] Prev/next doc navigation works via keyboard and click
- [x] CLI/Manual tabs stack vertically with line-variant underline, matching shadcn upstream
- [x] No overflowing code blocks on the Manual install tab at wide viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)