### PR TITLE
fix(v4): center header vertical separators

### DIFF
--- a/apps/v4/src/components/site-header.tsx
+++ b/apps/v4/src/components/site-header.tsx
@@ -17,7 +17,7 @@ export function SiteHeader() {
   return (
     <header className="sticky top-0 z-50 w-full bg-background">
       <div className="container-wrapper px-6 3xl:fixed:px-0">
-        <div className="flex h-(--header-height) items-center gap-2 **:data-[slot=separator]:h-4! 3xl:fixed:container">
+        <div className="flex h-(--header-height) items-center gap-2 **:data-[slot=separator]:h-4! **:data-[slot=separator]:self-center! 3xl:fixed:container">
           <MobileNav
             tree={pageTree}
             items={siteConfig.navItems}


### PR DESCRIPTION
## Summary

Fixes the header's vertical dividers sitting flush against the top of the row instead of vertically centered (triaged in ROADMAP Phase 4b, 2026-07-15).

Root cause: the vendored base-nova `Separator` carries `data-vertical:self-stretch`, which overrides the header row's `items-center`. Once the header caps the separator at `**:data-[slot=separator]:h-4!`, "stretch" degrades to top alignment. shadcn's own site never hits this because their header still imports the Radix `new-york-v4` separator whose vertical class is `h-full`.

Fix: add `**:data-[slot=separator]:self-center!` next to the existing `h-4!` cap on the header row, keeping the vendored separator byte-identical to upstream.

## Test plan

- [x] Measured in browser: both separators now span y 24–40 in the 64px header (midpoint 32, same as the icon buttons); previously they sat at y 16–32.
- [x] Visual check at lg viewport — dividers centered between search box / GitHub link / mode switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)