### PR TITLE
feat(registry): migrate input-base dependents to shadcn input-group

### DIFF
--- a/apps/v4/content/docs/components/calendar.mdx
+++ b/apps/v4/content/docs/components/calendar.mdx
@@ -8,7 +8,7 @@ links:
 
 <Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
 
-**Note**: This component is a copy of the official shadcn/ui [Calendar](https://ui.shadcn.com/docs/components/calendar) component, kept in sync and published on the ui-x registry so that components such as [Date Picker](/docs/components/date-picker) can build on it. We recommend using the official version.
+**Note**: This component was originally published to provide a newer version of React DayPicker with month and year dropdown selects before the official shadcn/ui [Calendar](https://ui.shadcn.com/docs/components/calendar) supported them. The official component has since caught up, and this copy is now kept in sync with it and published on the ui-x registry so that components such as [Date Picker](/docs/components/date-picker) can build on it. We recommend using the official version.
 
 </Callout>
 

--- a/apps/v4/content/docs/components/calendar.mdx
+++ b/apps/v4/content/docs/components/calendar.mdx
@@ -6,6 +6,12 @@ links:
   api: https://daypicker.dev/api
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: This component is a copy of the official shadcn/ui [Calendar](https://ui.shadcn.com/docs/components/calendar) component, kept in sync and published on the ui-x registry so that components such as [Date Picker](/docs/components/date-picker) can build on it. We recommend using the official version.
+
+</Callout>
+
 <ComponentPreview
   name="calendar-demo"
   title="Calendar"

--- a/apps/v4/content/docs/components/combobox.mdx
+++ b/apps/v4/content/docs/components/combobox.mdx
@@ -44,13 +44,13 @@ npm install @radix-ui/react-slot
 
 <Step>
 
-Add the `<Badge />`, `<ComboboxPrimitive />` and `<InputBase />` component to your project.
+Add the `<Badge />`, `<ComboboxPrimitive />` and `<InputGroup />` component to your project.
 
 </Step>
 
-The `<Combobox />` component uses `<Badge />`, `<ComboboxPrimitive />` and `<InputBase />` components. Make sure you have it installed in your project.
+The `<Combobox />` component uses `<Badge />`, `<ComboboxPrimitive />` and `<InputGroup />` components. Make sure you have it installed in your project.
 
-See installation instructions for the [Badge](/docs/components/badge#installation), [ComboboxPrimitive](/docs/components/combobox-primitive#installation) and the [InputBase](/docs/components/input-base#installation) components.
+See installation instructions for the [Badge](/docs/components/badge#installation), [ComboboxPrimitive](/docs/components/combobox-primitive#installation) and the [Input Group](https://ui.shadcn.com/docs/components/input-group) components.
 
 <Step>Copy and paste the following code into your project.</Step>
 

--- a/apps/v4/content/docs/components/date-picker.mdx
+++ b/apps/v4/content/docs/components/date-picker.mdx
@@ -30,13 +30,13 @@ npx shadcn@latest add junwen-k/ui-x/date-picker
 
 <Step>
 
-Add the `<Button />`, `<Calendar />`, `<DateField />`, `<DatePickerPrimitive />` and `<InputBase />` component to your project.
+Add the `<Button />`, `<Calendar />`, `<DateField />`, `<DatePickerPrimitive />` and `<InputGroup />` component to your project.
 
 </Step>
 
-The `<DatePicker />` component uses `<Button />`, `<Calendar />`, `<DateField />`, `<DatePickerPrimitive />` and `<InputBase />` components. Make sure you have it installed in your project.
+The `<DatePicker />` component uses `<Button />`, `<Calendar />`, `<DateField />`, `<DatePickerPrimitive />` and `<InputGroup />` components. Make sure you have it installed in your project.
 
-See installation instructions for the [Button](/docs/components/button#installation), [Calendar](/docs/components/calendar#installation), [DateField](/docs/components/date-field#installation), [DatePickerPrimitive](/docs/components/date-picker-primitive#installation) and the [InputBase](/docs/components/input-base#installation) components.
+See installation instructions for the [Button](/docs/components/button#installation), [Calendar](/docs/components/calendar#installation), [DateField](/docs/components/date-field#installation), [DatePickerPrimitive](/docs/components/date-picker-primitive#installation) and the [Input Group](https://ui.shadcn.com/docs/components/input-group) components.
 
 <Step>Copy and paste the following code into your project.</Step>
 

--- a/apps/v4/content/docs/components/date-time-field.mdx
+++ b/apps/v4/content/docs/components/date-time-field.mdx
@@ -30,13 +30,13 @@ npx shadcn@latest add junwen-k/ui-x/date-time-field
 
 <Step>
 
-Add `<DateTimeFieldPrimitive />` and `<InputBase />` component to your project.
+Add `<DateTimeFieldPrimitive />` and `<InputGroup />` component to your project.
 
 </Step>
 
-The `<DateTimeField />` component uses `<DateTimeFieldPrimitive />` and `<InputBase />` components. Make sure you have it installed in your project.
+The `<DateTimeField />` component uses `<DateTimeFieldPrimitive />` and `<InputGroup />` components. Make sure you have it installed in your project.
 
-See installation instructions for the [DateTimeFieldPrimitive](/docs/components/date-time-field-primitive#installation) and [InputBase](/docs/components/input-base#installation) components.
+See installation instructions for the [DateTimeFieldPrimitive](/docs/components/date-time-field-primitive#installation) and [Input Group](https://ui.shadcn.com/docs/components/input-group) components.
 
 <Step>Copy and paste the following code into your project.</Step>
 

--- a/apps/v4/content/docs/components/date-time-range-field.mdx
+++ b/apps/v4/content/docs/components/date-time-range-field.mdx
@@ -30,13 +30,13 @@ npx shadcn@latest add junwen-k/ui-x/date-time-range-field
 
 <Step>
 
-Add `<DateTimeField />`, `<DateTimeRangeFieldPrimitive />` and `<InputBase />` component to your project.
+Add `<DateTimeField />`, `<DateTimeRangeFieldPrimitive />` and `<InputGroup />` component to your project.
 
 </Step>
 
-The `<DateTimeRangeField />` component uses `<DateTimeField />`, `<DateTimeRangeFieldPrimitive />` and `<InputBase />` components. Make sure you have it installed in your project.
+The `<DateTimeRangeField />` component uses `<DateTimeField />`, `<DateTimeRangeFieldPrimitive />` and `<InputGroup />` components. Make sure you have it installed in your project.
 
-See installation instructions for the [DateTimeField](/docs/components/date-time-field#installation), [DateTimeRangeFieldPrimitive](/docs/primitives/date-time-range-field#installation), [InputBase](/docs/primitives/input-base#installation) components.
+See installation instructions for the [DateTimeField](/docs/components/date-time-field#installation), [DateTimeRangeFieldPrimitive](/docs/primitives/date-time-range-field#installation), [Input Group](https://ui.shadcn.com/docs/components/input-group) components.
 
 <Step>Copy and paste the following code into your project.</Step>
 

--- a/apps/v4/content/docs/components/input-base.mdx
+++ b/apps/v4/content/docs/components/input-base.mdx
@@ -5,7 +5,7 @@ description: Base component to create custom inputs.
 
 <Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
 
-**Note**: shadcn/ui now includes an [Input Group](https://ui.shadcn.com/docs/components/input-group) component, added in October 2025, for decorating inputs with icons, buttons and text. For that use case we recommend the official version — this component predates it and is provided as-is. Input Base still serves as the foundation for other ui-x components such as [Combobox](/docs/components/combobox) and the date/time fields.
+**Note**: shadcn/ui now includes an [Input Group](https://ui.shadcn.com/docs/components/input-group) component, added in October 2025, for decorating inputs with icons, buttons and text. We recommend using the official version — this component predates it and is provided as-is. Other ui-x components such as [Combobox](/docs/components/combobox) and the date/time fields now build on Input Group.
 
 </Callout>
 

--- a/apps/v4/content/docs/components/meta.json
+++ b/apps/v4/content/docs/components/meta.json
@@ -17,7 +17,7 @@
     "time",
     "timeline",
     "wheel-picker",
-    "---Provided as-is---",
+    "---In shadcn/ui---",
     "calendar",
     "combobox",
     "control-group",

--- a/apps/v4/content/docs/components/meta.json
+++ b/apps/v4/content/docs/components/meta.json
@@ -3,10 +3,7 @@
   "pages": [
     "badge-group",
     "bprogress",
-    "calendar",
-    "combobox",
     "confirmer",
-    "control-group",
     "date-field",
     "date-time-field",
     "date-time-range-field",
@@ -14,15 +11,19 @@
     "emoji-picker",
     "description-list",
     "dropzone",
-    "file-list",
-    "input-base",
-    "kbd",
-    "native-select",
     "password-input",
     "phone-input",
     "time-field",
     "time",
     "timeline",
-    "wheel-picker"
+    "wheel-picker",
+    "---Provided as-is---",
+    "calendar",
+    "combobox",
+    "control-group",
+    "file-list",
+    "input-base",
+    "kbd",
+    "native-select"
   ]
 }

--- a/apps/v4/content/docs/components/native-select.mdx
+++ b/apps/v4/content/docs/components/native-select.mdx
@@ -25,16 +25,6 @@ npx shadcn@latest add junwen-k/ui-x/native-select
 
 <Steps>
 
-<Step>
-
-Add `<InputBase />` component to your project.
-
-</Step>
-
-The `<NativeSelect />` component uses `<InputBase />` component. Make sure you have it installed in your project.
-
-See installation instructions for the [InputBase](/docs/components/input-base#installation) component.
-
 <Step>Copy and paste the following code into your project.</Step>
 
 <ComponentSource name="native-select" />

--- a/apps/v4/content/docs/components/native-select.mdx
+++ b/apps/v4/content/docs/components/native-select.mdx
@@ -3,6 +3,12 @@ title: Native Select
 description: Native select element.
 ---
 
+<Callout className="mt-4 border-amber-200 bg-amber-50 dark:border-amber-950 dark:bg-amber-950/50 [&_[data-slot=alert-description]]:text-foreground">
+
+**Note**: shadcn/ui now includes its own [Native Select](https://ui.shadcn.com/docs/components/native-select) component. We recommend using the official version — this component predates it and is provided as-is.
+
+</Callout>
+
 <ComponentPreview name="native-select-demo" />
 
 ## Installation

--- a/apps/v4/content/docs/components/password-input.mdx
+++ b/apps/v4/content/docs/components/password-input.mdx
@@ -29,13 +29,13 @@ npx shadcn@latest add junwen-k/ui-x/password-input
 
 <Step>
 
-Add `<InputBase />` and `<PasswordInputPrimitive />` component to your project.
+Add `<InputGroup />` and `<PasswordInputPrimitive />` component to your project.
 
 </Step>
 
-The `<PasswordInput />` component uses `<InputBase />` and `<PasswordInputPrimitive />` components. Make sure you have it installed in your project.
+The `<PasswordInput />` component uses `<InputGroup />` and `<PasswordInputPrimitive />` components. Make sure you have it installed in your project.
 
-See installation instructions for the [InputBase](/docs/components/input-base#installation) and [PasswordInputPrimitive](/docs/components/password-input-primitive#installation) components.
+See installation instructions for the [Input Group](https://ui.shadcn.com/docs/components/input-group) and [PasswordInputPrimitive](/docs/components/password-input-primitive#installation) components.
 
 <Step>Copy and paste the following code into your project.</Step>
 

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -296,8 +296,8 @@
       ],
       "registryDependencies": [
         "badge",
-        "https://ui-x.junwen-k.dev/r/combobox-primitive.json",
-        "https://ui-x.junwen-k.dev/r/input-base.json"
+        "input-group",
+        "https://ui-x.junwen-k.dev/r/combobox-primitive.json"
       ],
       "files": [
         {
@@ -362,8 +362,8 @@
       "title": "Date Time Field",
       "description": "Date Time Field allows user to enter date and time value.",
       "registryDependencies": [
-        "https://ui-x.junwen-k.dev/r/date-time-field-primitive.json",
-        "https://ui-x.junwen-k.dev/r/input-base.json"
+        "input-group",
+        "https://ui-x.junwen-k.dev/r/date-time-field-primitive.json"
       ],
       "files": [
         {
@@ -378,9 +378,9 @@
       "title": "Date Time Range Field",
       "description": "Date Time Range Field allows user to enter date and time value for a range of dates.",
       "registryDependencies": [
+        "input-group",
         "https://ui-x.junwen-k.dev/r/date-time-field.json",
-        "https://ui-x.junwen-k.dev/r/date-time-range-field-primitive.json",
-        "https://ui-x.junwen-k.dev/r/input-base.json"
+        "https://ui-x.junwen-k.dev/r/date-time-range-field-primitive.json"
       ],
       "files": [
         {
@@ -396,10 +396,10 @@
       "description": "A date picker component lets users select a date.",
       "registryDependencies": [
         "button",
+        "input-group",
         "https://ui-x.junwen-k.dev/r/calendar.json",
         "https://ui-x.junwen-k.dev/r/date-field.json",
-        "https://ui-x.junwen-k.dev/r/date-picker-primitive.json",
-        "https://ui-x.junwen-k.dev/r/input-base.json"
+        "https://ui-x.junwen-k.dev/r/date-picker-primitive.json"
       ],
       "files": [
         {
@@ -498,9 +498,6 @@
       "type": "registry:ui",
       "title": "Native Select",
       "description": "Native select element.",
-      "registryDependencies": [
-        "https://ui-x.junwen-k.dev/r/input-base.json"
-      ],
       "files": [
         {
           "path": "src/registry/new-york/ui/native-select.tsx",
@@ -514,7 +511,7 @@
       "title": "Password Input",
       "description": "Password Input provides a way for the user to securely enter a password, with the ability to toggle the visibility of the password.",
       "registryDependencies": [
-        "https://ui-x.junwen-k.dev/r/input-base.json",
+        "input-group",
         "https://ui-x.junwen-k.dev/r/password-input-primitive.json"
       ],
       "files": [

--- a/apps/v4/src/components/card-demo-form.tsx
+++ b/apps/v4/src/components/card-demo-form.tsx
@@ -25,17 +25,16 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import {
   DatePicker,
   DatePickerCalendar,
   DatePickerContent,
   DatePickerInput,
 } from "@/registry/new-york/ui/date-picker";
-import {
-  InputBase,
-  InputBaseAdornment,
-  InputBaseControl,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
 import {
   PasswordInput,
   PasswordInputAdornment,
@@ -107,19 +106,17 @@ export function CardWithForm() {
             <FormField
               control={form.control}
               name="username"
-              render={({ field, fieldState }) => (
+              render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username</FormLabel>
-                  <InputBase error={Boolean(fieldState.error)}>
-                    <InputBaseAdornment>
+                  <InputGroup>
+                    <InputGroupAddon>
                       <UserRoundPenIcon />
-                    </InputBaseAdornment>
-                    <InputBaseControl>
-                      <FormControl>
-                        <InputBaseInput placeholder="junwen-k" {...field} />
-                      </FormControl>
-                    </InputBaseControl>
-                  </InputBase>
+                    </InputGroupAddon>
+                    <FormControl>
+                      <InputGroupInput placeholder="junwen-k" {...field} />
+                    </FormControl>
+                  </InputGroup>
                   <FormMessage />
                 </FormItem>
               )}
@@ -127,22 +124,20 @@ export function CardWithForm() {
             <FormField
               control={form.control}
               name="email"
-              render={({ field, fieldState }) => (
+              render={({ field }) => (
                 <FormItem>
                   <FormLabel>Email</FormLabel>
-                  <InputBase error={Boolean(fieldState.error)}>
-                    <InputBaseAdornment>
+                  <InputGroup>
+                    <InputGroupAddon>
                       <MailIcon />
-                    </InputBaseAdornment>
-                    <InputBaseControl>
-                      <FormControl>
-                        <InputBaseInput
-                          placeholder="example@junwen-k.dev"
-                          {...field}
-                        />
-                      </FormControl>
-                    </InputBaseControl>
-                  </InputBase>
+                    </InputGroupAddon>
+                    <FormControl>
+                      <InputGroupInput
+                        placeholder="example@junwen-k.dev"
+                        {...field}
+                      />
+                    </FormControl>
+                  </InputGroup>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/v4/src/components/docs-sidebar.tsx
+++ b/apps/v4/src/components/docs-sidebar.tsx
@@ -15,7 +15,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { PAGES_NEW } from "@/lib/docs";
-import { getOwnPagesFromFolder, getTopLevelSections } from "@/lib/page-tree";
+import { getOwnSectionsFromFolder, getTopLevelSections } from "@/lib/page-tree";
 
 export function DocsSidebar({
   tree,
@@ -63,19 +63,19 @@ export function DocsSidebar({
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-        {tree.children.map((item) => {
+        {tree.children.flatMap((item) => {
           if (item.type !== "folder") {
             return null;
           }
 
-          return (
-            <SidebarGroup key={item.$id}>
+          return getOwnSectionsFromFolder(item).map((section, index) => (
+            <SidebarGroup key={`${item.$id}-${index}`}>
               <SidebarGroupLabel className="font-medium text-muted-foreground">
-                {item.name}
+                {section.name ?? item.name}
               </SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu className="gap-0.5">
-                  {getOwnPagesFromFolder(item).map((page) => (
+                  {section.pages.map((page) => (
                     <SidebarMenuItem key={page.url}>
                       <SidebarMenuButton
                         isActive={page.url === pathname}
@@ -98,7 +98,7 @@ export function DocsSidebar({
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>
-          );
+          ));
         })}
       </SidebarContent>
     </Sidebar>

--- a/apps/v4/src/components/examples/emoji-picker-form.tsx
+++ b/apps/v4/src/components/examples/emoji-picker-form.tsx
@@ -18,6 +18,11 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+} from "@/components/ui/input-group";
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -33,10 +38,6 @@ import {
   EmojiPickerFooter,
   EmojiPickerSearch,
 } from "@/registry/new-york/ui/emoji-picker";
-import {
-  InputBase,
-  InputBaseAdornmentButton,
-} from "@/registry/new-york/ui/input-base";
 
 const FormSchema = z.object({
   message: z.string().min(1, { message: "Message is required" }),
@@ -96,15 +97,21 @@ export default function EmojiPickerForm() {
                     </FormControl>
                   </ControlGroupItem>
                   <ControlGroupItem>
-                    <InputBase
-                      className="before:flex-1"
-                      error={Boolean(fieldState.error)}
-                    >
-                      <PopoverTrigger render={<InputBaseAdornmentButton />}>
-                        <SmilePlusIcon />
-                        <span className="sr-only">Pick emoji</span>
-                      </PopoverTrigger>
-                    </InputBase>
+                    <InputGroup>
+                      <InputGroupAddon align="inline-end" className="ml-auto">
+                        <PopoverTrigger
+                          render={
+                            <InputGroupButton
+                              size="icon-xs"
+                              aria-invalid={Boolean(fieldState.error)}
+                            />
+                          }
+                        >
+                          <SmilePlusIcon />
+                          <span className="sr-only">Pick emoji</span>
+                        </PopoverTrigger>
+                      </InputGroupAddon>
+                    </InputGroup>
                   </ControlGroupItem>
                 </ControlGroup>
                 <FormMessage />

--- a/apps/v4/src/components/examples/phone-input-combobox.tsx
+++ b/apps/v4/src/components/examples/phone-input-combobox.tsx
@@ -9,6 +9,7 @@ import {
   CommandGroup as ComboboxGroup,
   CommandList as ComboboxList,
 } from "@/components/ui/command";
+import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
 import { PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import {
@@ -21,11 +22,6 @@ import {
   ControlGroup,
   ControlGroupItem,
 } from "@/registry/new-york/ui/control-group";
-import {
-  InputBase,
-  InputBaseControl,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
 import {
   Country,
   PhoneInput,
@@ -118,13 +114,11 @@ export default function PhoneInputCombobox() {
               </ComboboxPrimitive.Content>
             </ComboboxPrimitive.Portal>
             <ControlGroupItem>
-              <InputBase>
-                <InputBaseControl>
-                  <PhoneInputPrimitive.Input asChild>
-                    <InputBaseInput />
-                  </PhoneInputPrimitive.Input>
-                </InputBaseControl>
-              </InputBase>
+              <InputGroup>
+                <PhoneInputPrimitive.Input asChild>
+                  <InputGroupInput />
+                </PhoneInputPrimitive.Input>
+              </InputGroup>
             </ControlGroupItem>
           </ControlGroup>
         </ComboboxPrimitive.Anchor>

--- a/apps/v4/src/components/examples/phone-input-demo.tsx
+++ b/apps/v4/src/components/examples/phone-input-demo.tsx
@@ -2,15 +2,11 @@
 
 import * as React from "react";
 
+import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
 import {
   ControlGroup,
   ControlGroupItem,
 } from "@/registry/new-york/ui/control-group";
-import {
-  InputBase,
-  InputBaseControl,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
 import {
   PhoneInput,
   PhoneInputCountrySelect,
@@ -36,13 +32,11 @@ export default function PhoneInputDemo() {
           </PhoneInputCountrySelectContent>
         </PhoneInputCountrySelect>
         <ControlGroupItem>
-          <InputBase>
-            <InputBaseControl>
-              <PhoneInputPrimitive.Input asChild>
-                <InputBaseInput />
-              </PhoneInputPrimitive.Input>
-            </InputBaseControl>
-          </InputBase>
+          <InputGroup>
+            <PhoneInputPrimitive.Input asChild>
+              <InputGroupInput />
+            </PhoneInputPrimitive.Input>
+          </InputGroup>
         </ControlGroupItem>
       </ControlGroup>
     </PhoneInput>

--- a/apps/v4/src/components/examples/phone-input-separated.tsx
+++ b/apps/v4/src/components/examples/phone-input-separated.tsx
@@ -5,11 +5,10 @@ import * as React from "react";
 import { getCountryCallingCode } from "react-phone-number-input";
 
 import {
-  InputBase,
-  InputBaseAdornment,
-  InputBaseControl,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import {
   Country,
   PhoneInput,
@@ -40,18 +39,16 @@ export default function PhoneInputSeparated() {
               <PhoneInputCountrySelectOptions />
             </PhoneInputCountrySelectContent>
           </PhoneInputCountrySelect>
-          <InputBase>
-            <InputBaseAdornment>
+          <InputGroup>
+            <InputGroupAddon>
               {country ? `+${getCountryCallingCode(country)}` : <PhoneIcon />}
-            </InputBaseAdornment>
-            <InputBaseControl>
-              <PhoneInputPrimitive.Input asChild>
-                <InputBaseInput
-                  placeholder={country === null ? "012-345 6789" : undefined}
-                />
-              </PhoneInputPrimitive.Input>
-            </InputBaseControl>
-          </InputBase>
+            </InputGroupAddon>
+            <PhoneInputPrimitive.Input asChild>
+              <InputGroupInput
+                placeholder={country === null ? "012-345 6789" : undefined}
+              />
+            </PhoneInputPrimitive.Input>
+          </InputGroup>
         </div>
         <p className="text-muted-foreground text-sm">
           Preferred country has been set to{" "}

--- a/apps/v4/src/components/examples/wheel-picker-form.tsx
+++ b/apps/v4/src/components/examples/wheel-picker-form.tsx
@@ -19,12 +19,12 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { InputGroupButton } from "@/components/ui/input-group";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { InputBaseAdornmentButton } from "@/registry/new-york/ui/input-base";
 import {
   TimeField,
   TimeFieldAmPm,
@@ -119,7 +119,7 @@ export default function WheelPickerForm() {
                     <TimeFieldAmPm />
                     <PopoverTrigger
                       className="ml-auto"
-                      render={<InputBaseAdornmentButton />}
+                      render={<InputGroupButton size="icon-xs" />}
                     >
                       <ClockIcon />
                     </PopoverTrigger>

--- a/apps/v4/src/components/mobile-nav.tsx
+++ b/apps/v4/src/components/mobile-nav.tsx
@@ -12,7 +12,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { PAGES_NEW } from "@/lib/docs";
-import { getOwnPagesFromFolder, getTopLevelSections } from "@/lib/page-tree";
+import { getOwnSectionsFromFolder, getTopLevelSections } from "@/lib/page-tree";
 import { cn } from "@/lib/utils";
 
 export function MobileNav({
@@ -103,18 +103,21 @@ export function MobileNav({
               ))}
             </div>
           </div>
-          {tree.children.map((group) => {
+          {tree.children.flatMap((group) => {
             if (group.type !== "folder") {
               return null;
             }
 
-            return (
-              <div key={group.$id} className="flex flex-col gap-4">
+            return getOwnSectionsFromFolder(group).map((section, index) => (
+              <div
+                key={`${group.$id}-${index}`}
+                className="flex flex-col gap-4"
+              >
                 <div className="text-sm font-medium text-muted-foreground">
-                  {group.name}
+                  {section.name ?? group.name}
                 </div>
                 <div className="flex flex-col gap-3">
-                  {getOwnPagesFromFolder(group).map((page) => (
+                  {section.pages.map((page) => (
                     <MobileLink
                       key={page.url}
                       href={page.url}
@@ -128,7 +131,7 @@ export function MobileNav({
                   ))}
                 </div>
               </div>
-            );
+            ));
           })}
         </div>
       </PopoverContent>

--- a/apps/v4/src/lib/page-tree.ts
+++ b/apps/v4/src/lib/page-tree.ts
@@ -1,4 +1,5 @@
 import type * as PageTree from "fumadocs-core/page-tree";
+import type * as React from "react";
 
 /**
  * Flattens a page tree folder into its pages, including the folder's index
@@ -24,33 +25,49 @@ export function getPagesFromFolder(folder: PageTree.Folder): PageTree.Item[] {
   );
 }
 
+export interface FolderSection {
+  name?: React.ReactNode;
+  pages: PageTree.Item[];
+}
+
 /**
- * A folder's own pages: its index page plus its direct page children.
- * Nested folders (e.g. a component with framework-specific sub-pages like
- * bprogress/next) contribute only their index page, not their descendants —
- * those sub-pages are only reachable via linked cards on that index page,
- * matching shadcn/ui's dark-mode-style sub-pages.
+ * A folder's own pages — its index page plus its direct page children — split
+ * into sections at separator entries (`---Label---` in meta.json). The first
+ * section is unnamed and holds the pages before any separator. Nested folders
+ * (e.g. a component with framework-specific sub-pages like bprogress/next)
+ * contribute only their index page, not their descendants — those sub-pages
+ * are only reachable via linked cards on that index page, matching
+ * shadcn/ui's dark-mode-style sub-pages.
  */
-export function getOwnPagesFromFolder(
+export function getOwnSectionsFromFolder(
   folder: PageTree.Folder,
-): PageTree.Item[] {
-  const pages: PageTree.Item[] = [];
+): FolderSection[] {
+  const sections: FolderSection[] = [{ pages: [] }];
+  const seen = new Set<string>();
+
+  const push = (page: PageTree.Item) => {
+    if (seen.has(page.url)) {
+      return;
+    }
+    seen.add(page.url);
+    sections[sections.length - 1].pages.push(page);
+  };
 
   if (folder.index) {
-    pages.push(folder.index);
+    push(folder.index);
   }
 
   for (const child of folder.children) {
-    if (child.type === "page") {
-      pages.push(child);
+    if (child.type === "separator") {
+      sections.push({ name: child.name, pages: [] });
+    } else if (child.type === "page") {
+      push(child);
     } else if (child.type === "folder" && child.index) {
-      pages.push(child.index);
+      push(child.index);
     }
   }
 
-  return pages.filter(
-    (page, index, all) => all.findIndex((p) => p.url === page.url) === index,
-  );
+  return sections.filter((section) => section.pages.length > 0);
 }
 
 /**

--- a/apps/v4/src/registry/new-york/ui/combobox.tsx
+++ b/apps/v4/src/registry/new-york/ui/combobox.tsx
@@ -11,37 +11,38 @@ import {
 import * as React from "react";
 
 import { badgeVariants } from "@/components/ui/badge";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 import * as ComboboxPrimitive from "@/registry/new-york/ui/combobox-primitive";
-import {
-  InputBase,
-  InputBaseAdornmentButton,
-  InputBaseControl,
-  InputBaseFlexWrapper,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
 
 export const Combobox = ComboboxPrimitive.Root;
 
-function ComboboxInputBase({
+function ComboboxInputGroup({
   children,
   ...props
-}: React.ComponentProps<typeof InputBase>) {
+}: React.ComponentProps<typeof InputGroup>) {
   return (
     <ComboboxPrimitive.Anchor asChild>
-      <InputBase data-slot="combobox-input-base" {...props}>
+      <InputGroup data-slot="combobox-input-group" {...props}>
         {children}
-        <ComboboxPrimitive.Clear asChild>
-          <InputBaseAdornmentButton>
-            <XIcon />
-          </InputBaseAdornmentButton>
-        </ComboboxPrimitive.Clear>
-        <ComboboxPrimitive.Trigger asChild>
-          <InputBaseAdornmentButton>
-            <ChevronsUpDownIcon />
-          </InputBaseAdornmentButton>
-        </ComboboxPrimitive.Trigger>
-      </InputBase>
+        <InputGroupAddon align="inline-end">
+          <ComboboxPrimitive.Clear asChild>
+            <InputGroupButton size="icon-xs">
+              <XIcon />
+            </InputGroupButton>
+          </ComboboxPrimitive.Clear>
+          <ComboboxPrimitive.Trigger asChild>
+            <InputGroupButton size="icon-xs">
+              <ChevronsUpDownIcon />
+            </InputGroupButton>
+          </ComboboxPrimitive.Trigger>
+        </InputGroupAddon>
+      </InputGroup>
     </ComboboxPrimitive.Anchor>
   );
 }
@@ -50,13 +51,11 @@ function ComboboxInput(
   props: React.ComponentProps<typeof ComboboxPrimitive.Input>,
 ) {
   return (
-    <ComboboxInputBase>
-      <InputBaseControl>
-        <ComboboxPrimitive.Input asChild>
-          <InputBaseInput data-slot="combobox-input" {...props} />
-        </ComboboxPrimitive.Input>
-      </InputBaseControl>
-    </ComboboxInputBase>
+    <ComboboxInputGroup>
+      <ComboboxPrimitive.Input asChild>
+        <InputGroupInput data-slot="combobox-input" {...props} />
+      </ComboboxPrimitive.Input>
+    </ComboboxInputGroup>
   );
 }
 
@@ -65,21 +64,19 @@ function ComboboxTagsInput({
   ...props
 }: React.ComponentProps<typeof ComboboxPrimitive.Input>) {
   return (
-    <ComboboxInputBase>
+    <ComboboxInputGroup className="h-auto min-h-8">
       <ComboboxPrimitive.TagGroup asChild>
-        <InputBaseFlexWrapper
+        <div
           data-slot="combobox-tags-input"
-          className="flex items-center gap-2"
+          className="flex flex-1 flex-wrap items-center gap-1.5 py-1 pl-2.5"
         >
           {children}
-          <InputBaseControl>
-            <ComboboxPrimitive.Input asChild>
-              <InputBaseInput {...props} />
-            </ComboboxPrimitive.Input>
-          </InputBaseControl>
-        </InputBaseFlexWrapper>
+          <ComboboxPrimitive.Input asChild>
+            <InputGroupInput className="h-6 px-0" {...props} />
+          </ComboboxPrimitive.Input>
+        </div>
       </ComboboxPrimitive.TagGroup>
-    </ComboboxInputBase>
+    </ComboboxInputGroup>
   );
 }
 
@@ -220,7 +217,7 @@ function ComboboxItem({ className, children, ...props }: ComboboxItemProps) {
 }
 
 export {
-  ComboboxInputBase,
+  ComboboxInputGroup,
   ComboboxInput,
   ComboboxTagsInput,
   ComboboxTag,

--- a/apps/v4/src/registry/new-york/ui/date-picker.tsx
+++ b/apps/v4/src/registry/new-york/ui/date-picker.tsx
@@ -3,7 +3,12 @@
 import { CalendarIcon, XIcon } from "lucide-react";
 import * as React from "react";
 
-import { buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+} from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 import { Calendar } from "@/registry/new-york/ui/calendar";
 import {
@@ -13,12 +18,6 @@ import {
   DateFieldYears,
 } from "@/registry/new-york/ui/date-field";
 import * as DatePickerPrimitive from "@/registry/new-york/ui/date-picker-primitive";
-import {
-  InputBase,
-  InputBaseAdornment,
-  InputBaseAdornmentButton,
-  InputBaseFlexWrapper,
-} from "@/registry/new-york/ui/input-base";
 
 function DatePicker(
   props: React.ComponentProps<typeof DatePickerPrimitive.Root>,
@@ -34,30 +33,33 @@ function DatePickerAnchor(
   );
 }
 
-function DatePickerInputBase({
+function DatePickerInputGroup({
   children,
+  className,
   ...props
-}: React.ComponentProps<typeof InputBase>) {
+}: React.ComponentProps<typeof InputGroup>) {
   return (
     <DatePickerPrimitive.Anchor asChild>
-      <InputBase data-slot="date-picker-input-base" {...props}>
-        <InputBaseFlexWrapper>{children}</InputBaseFlexWrapper>
-        <InputBaseAdornment>
-          <InputBaseAdornmentButton asChild>
-            <DatePickerPrimitive.Clear>
+      <InputGroup
+        data-slot="date-picker-input-group"
+        className={cn("pl-2", className)}
+        {...props}
+      >
+        <div className="flex flex-1 items-center">{children}</div>
+        <InputGroupAddon align="inline-end">
+          <DatePickerPrimitive.Clear asChild>
+            <InputGroupButton size="icon-xs">
               <span className="sr-only">Clear date</span>
               <XIcon />
-            </DatePickerPrimitive.Clear>
-          </InputBaseAdornmentButton>
-        </InputBaseAdornment>
-        <InputBaseAdornment>
-          <InputBaseAdornmentButton asChild>
-            <DatePickerPrimitive.Trigger>
+            </InputGroupButton>
+          </DatePickerPrimitive.Clear>
+          <DatePickerPrimitive.Trigger asChild>
+            <InputGroupButton size="icon-xs">
               <CalendarIcon />
-            </DatePickerPrimitive.Trigger>
-          </InputBaseAdornmentButton>
-        </InputBaseAdornment>
-      </InputBase>
+            </InputGroupButton>
+          </DatePickerPrimitive.Trigger>
+        </InputGroupAddon>
+      </InputGroup>
     </DatePickerPrimitive.Anchor>
   );
 }
@@ -161,7 +163,7 @@ function DatePickerInput({
   const { mode } = DatePickerPrimitive.useDatePicker();
 
   return (
-    <DatePickerInputBase className={className}>
+    <DatePickerInputGroup className={className}>
       {mode === "range" ? (
         <DatePickerDateRangeField
           {...(props as React.ComponentProps<typeof DatePickerDateRangeField>)}
@@ -171,7 +173,7 @@ function DatePickerInput({
           {...(props as React.ComponentProps<typeof DatePickerDateField>)}
         />
       )}
-    </DatePickerInputBase>
+    </DatePickerInputGroup>
   );
 }
 
@@ -181,22 +183,19 @@ function DatePickerTrigger({
   ...props
 }: React.ComponentProps<typeof DatePickerPrimitive.Trigger>) {
   return (
-    <InputBase
+    <DatePickerPrimitive.Trigger
       data-slot="date-picker-trigger"
       asChild
-      className={cn(
-        buttonVariants({ variant: "outline" }),
-        "cursor-pointer font-normal",
-        className,
-      )}
+      {...props}
     >
-      <DatePickerPrimitive.Trigger {...props}>
-        <InputBaseAdornment>
-          <CalendarIcon />
-        </InputBaseAdornment>
-        <InputBaseFlexWrapper>{children}</InputBaseFlexWrapper>
-      </DatePickerPrimitive.Trigger>
-    </InputBase>
+      <Button
+        variant="outline"
+        className={cn("w-full justify-start font-normal", className)}
+      >
+        <CalendarIcon className="text-muted-foreground" />
+        {children}
+      </Button>
+    </DatePickerPrimitive.Trigger>
   );
 }
 

--- a/apps/v4/src/registry/new-york/ui/date-time-field.tsx
+++ b/apps/v4/src/registry/new-york/ui/date-time-field.tsx
@@ -2,13 +2,9 @@
 
 import * as React from "react";
 
+import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 import * as DateTimeFieldPrimitive from "@/registry/new-york/ui/date-time-field-primitive";
-import {
-  InputBase,
-  InputBaseControl,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
 
 function DateTimeField({
   children,
@@ -17,7 +13,7 @@ function DateTimeField({
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Root>) {
   return (
     <DateTimeFieldPrimitive.Root data-slot="date-time-field" asChild {...props}>
-      <InputBase className={cn("gap-0", className)}>{children}</InputBase>
+      <InputGroup className={cn("px-2", className)}>{children}</InputGroup>
     </DateTimeFieldPrimitive.Root>
   );
 }
@@ -44,22 +40,20 @@ function DateTimeFieldYears({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Years>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.Years
-        data-slot="date-time-field-years"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(4ch_+_0.5rem)]",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.Years>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.Years
+      data-slot="date-time-field-years"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(4ch_+_0.5rem)]",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.Years>
   );
 }
 
@@ -69,22 +63,20 @@ function DateTimeFieldMonths({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Months>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.Months
-        data-slot="date-time-field-months"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(2ch_+_0.5rem)]",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.Months>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.Months
+      data-slot="date-time-field-months"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(2ch_+_0.5rem)]",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.Months>
   );
 }
 
@@ -94,22 +86,20 @@ function DateTimeFieldDays({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Days>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.Days
-        data-slot="date-time-field-days"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(2ch_+_0.5rem)]",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.Days>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.Days
+      data-slot="date-time-field-days"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(2ch_+_0.5rem)]",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.Days>
   );
 }
 
@@ -119,22 +109,20 @@ function DateTimeFieldHours({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Hours>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.Hours
-        data-slot="date-time-field-hours"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(2ch_+_0.5rem)]",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.Hours>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.Hours
+      data-slot="date-time-field-hours"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(2ch_+_0.5rem)]",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.Hours>
   );
 }
 
@@ -144,22 +132,20 @@ function DateTimeFieldMinutes({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Minutes>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.Minutes
-        data-slot="date-time-field-minutes"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(2ch_+_0.5rem)]",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.Minutes>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.Minutes
+      data-slot="date-time-field-minutes"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(2ch_+_0.5rem)]",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.Minutes>
   );
 }
 
@@ -169,22 +155,20 @@ function DateTimeFieldSeconds({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.Seconds>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.Seconds
-        data-slot="date-time-field-seconds"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(2ch_+_0.5rem)]",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.Seconds>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.Seconds
+      data-slot="date-time-field-seconds"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(2ch_+_0.5rem)]",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.Seconds>
   );
 }
 
@@ -194,22 +178,20 @@ function DateTimeFieldAmPm({
   ...props
 }: React.ComponentProps<typeof DateTimeFieldPrimitive.AmPm>) {
   return (
-    <InputBaseControl>
-      <DateTimeFieldPrimitive.AmPm
-        data-slot="date-time-field-am-pm"
-        asChild
-        placeholder={placeholder}
-        {...props}
-      >
-        <InputBaseInput
-          className={cn(
-            dateTimeFieldInputStyle,
-            "max-w-[calc(2ch_+_0.5rem)] text-center",
-            className,
-          )}
-        />
-      </DateTimeFieldPrimitive.AmPm>
-    </InputBaseControl>
+    <DateTimeFieldPrimitive.AmPm
+      data-slot="date-time-field-am-pm"
+      asChild
+      placeholder={placeholder}
+      {...props}
+    >
+      <InputGroupInput
+        className={cn(
+          dateTimeFieldInputStyle,
+          "max-w-[calc(2ch_+_0.5rem)] text-center",
+          className,
+        )}
+      />
+    </DateTimeFieldPrimitive.AmPm>
   );
 }
 

--- a/apps/v4/src/registry/new-york/ui/date-time-range-field.tsx
+++ b/apps/v4/src/registry/new-york/ui/date-time-range-field.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 
+import { InputGroup } from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 import {
   DateTimeFieldAmPm,
@@ -14,7 +15,6 @@ import {
   DateTimeFieldYears,
 } from "@/registry/new-york/ui/date-time-field";
 import * as DateTimeRangeFieldPrimitive from "@/registry/new-york/ui/date-time-range-field-primitive";
-import { InputBase } from "@/registry/new-york/ui/input-base";
 
 function DateTimeRangeField({
   children,
@@ -27,7 +27,9 @@ function DateTimeRangeField({
       asChild
       {...props}
     >
-      <InputBase className={cn("gap-1.5", className)}>{children}</InputBase>
+      <InputGroup className={cn("gap-1.5 px-2", className)}>
+        {children}
+      </InputGroup>
     </DateTimeRangeFieldPrimitive.Root>
   );
 }

--- a/apps/v4/src/registry/new-york/ui/native-select.tsx
+++ b/apps/v4/src/registry/new-york/ui/native-select.tsx
@@ -1,34 +1,38 @@
-"use client";
-
 import { ChevronDownIcon } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
-import {
-  InputBase,
-  InputBaseAdornment,
-  InputBaseControl,
-} from "@/registry/new-york/ui/input-base";
 
-function NativeSelect({ className, ...props }: React.ComponentProps<"select">) {
+type NativeSelectProps = Omit<React.ComponentProps<"select">, "size"> & {
+  size?: "sm" | "default";
+};
+
+function NativeSelect({
+  className,
+  size = "default",
+  ...props
+}: NativeSelectProps) {
   return (
-    <InputBase
-      data-slot="native-select"
+    <div
       className={cn(
-        "relative min-h-fit p-0 [&>select]:min-h-9 [&>select]:min-w-40 [&>select]:px-3 [&>select]:py-1",
+        "group/native-select relative w-fit has-[select:disabled]:opacity-50",
         className,
       )}
+      data-slot="native-select-wrapper"
+      data-size={size}
     >
-      <InputBaseControl>
-        <select
-          className="size-full flex-1 appearance-none bg-transparent outline-none"
-          {...props}
-        />
-      </InputBaseControl>
-      <InputBaseAdornment className="absolute top-1/2 right-0 -translate-y-1/2 pr-3">
-        <ChevronDownIcon className="opacity-50" />
-      </InputBaseAdornment>
-    </InputBase>
+      <select
+        data-slot="native-select"
+        data-size={size}
+        className="border-input selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-8 w-full min-w-0 appearance-none rounded-lg border bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors outline-none select-none focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:ring-3 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5"
+        {...props}
+      />
+      <ChevronDownIcon
+        className="text-muted-foreground pointer-events-none absolute top-1/2 right-2.5 size-4 -translate-y-1/2 select-none"
+        aria-hidden="true"
+        data-slot="native-select-icon"
+      />
+    </div>
   );
 }
 
@@ -39,7 +43,7 @@ function NativeSelectGroup({
   return (
     <optgroup
       data-slot="native-select-group"
-      className={cn("bg-popover text-popover-foreground", className)}
+      className={cn("bg-[Canvas] text-[CanvasText]", className)}
       {...props}
     />
   );
@@ -52,7 +56,7 @@ function NativeSelectOption({
   return (
     <option
       data-slot="native-select-option"
-      className={cn("bg-popover text-popover-foreground", className)}
+      className={cn("bg-[Canvas] text-[CanvasText]", className)}
       {...props}
     />
   );

--- a/apps/v4/src/registry/new-york/ui/password-input.tsx
+++ b/apps/v4/src/registry/new-york/ui/password-input.tsx
@@ -1,20 +1,19 @@
 import { EyeIcon, EyeOffIcon } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
 import {
-  InputBase,
-  InputBaseAdornment,
-  InputBaseAdornmentButton,
-  InputBaseControl,
-  InputBaseInput,
-} from "@/registry/new-york/ui/input-base";
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { cn } from "@/lib/utils";
 import * as PasswordInputPrimitive from "@/registry/new-york/ui/password-input-primitive";
 
 type PasswordInputProps = React.ComponentProps<
   typeof PasswordInputPrimitive.Root
 > &
-  React.ComponentProps<typeof InputBase>;
+  React.ComponentProps<typeof InputGroup>;
 
 function PasswordInput({
   visible,
@@ -28,23 +27,24 @@ function PasswordInput({
       defaultVisible={defaultVisible}
       onVisibleChange={onVisibleChange}
     >
-      <InputBase data-slot="password-input" {...props} />
+      <InputGroup data-slot="password-input" {...props} />
     </PasswordInputPrimitive.Root>
   );
 }
 
 function PasswordInputAdornment(
-  props: React.ComponentProps<typeof InputBaseAdornment>,
+  props: React.ComponentProps<typeof InputGroupAddon>,
 ) {
-  return <InputBaseAdornment data-slot="password-input-adornment" {...props} />;
+  return <InputGroupAddon data-slot="password-input-adornment" {...props} />;
 }
 
 function PasswordInputAdornmentButton(
-  props: React.ComponentProps<typeof InputBaseAdornmentButton>,
+  props: React.ComponentProps<typeof InputGroupButton>,
 ) {
   return (
-    <InputBaseAdornmentButton
+    <InputGroupButton
       data-slot="password-input-adornment-button"
+      size="icon-xs"
       {...props}
     />
   );
@@ -54,15 +54,13 @@ function PasswordInputInput(
   props: React.ComponentProps<typeof PasswordInputPrimitive.Input>,
 ) {
   return (
-    <InputBaseControl>
-      <PasswordInputPrimitive.Input
-        data-slot="password-input-input"
-        asChild
-        {...props}
-      >
-        <InputBaseInput />
-      </PasswordInputPrimitive.Input>
-    </InputBaseControl>
+    <PasswordInputPrimitive.Input
+      data-slot="password-input-input"
+      asChild
+      {...props}
+    >
+      <InputGroupInput />
+    </PasswordInputPrimitive.Input>
   );
 }
 
@@ -71,18 +69,19 @@ function PasswordInputAdornmentToggle({
   ...props
 }: React.ComponentProps<typeof PasswordInputPrimitive.Toggle>) {
   return (
-    <InputBaseAdornment>
-      <InputBaseAdornmentButton asChild>
-        <PasswordInputPrimitive.Toggle
-          data-slot="password-input-adornment-toggle"
-          className={cn("group", className)}
-          {...props}
-        >
+    <InputGroupAddon align="inline-end">
+      <PasswordInputPrimitive.Toggle
+        data-slot="password-input-adornment-toggle"
+        asChild
+        className={cn("group", className)}
+        {...props}
+      >
+        <InputGroupButton size="icon-xs">
           <EyeIcon className="hidden size-4 group-data-[state=visible]:block" />
           <EyeOffIcon className="block size-4 group-data-[state=visible]:hidden" />
-        </PasswordInputPrimitive.Toggle>
-      </InputBaseAdornmentButton>
-    </InputBaseAdornment>
+        </InputGroupButton>
+      </PasswordInputPrimitive.Toggle>
+    </InputGroupAddon>
   );
 }
 


### PR DESCRIPTION
## Summary

Migrates all registry components that depended on the ui-x `input-base` component to compose the vendored shadcn/ui [`input-group`](https://ui.shadcn.com/docs/components/input-group) component instead, continuing the style-refresh roadmap.

### Registry components

- **combobox** — `ComboboxInputBase` renamed to `ComboboxInputGroup`; input, clear and trigger now slot onto `InputGroupInput` / `InputGroupButton`. `ComboboxTagsInput` uses an `h-auto min-h-8` group so tags wrap naturally.
- **date-picker** — anchor group with clear + calendar trigger as `icon-xs` group buttons; `DatePickerTrigger` uses the plain outline `Button`.
- **date-time-field / date-time-range-field** — segment inputs slot onto `InputGroupInput` inside a single group.
- **password-input** — visibility toggle is an `InputGroupButton` in an inline-end addon.
- **native-select** — no longer needs a group wrapper; adopts shadcn's standalone select styling (appearance-none + absolute chevron), dropping the input-base dependency entirely.

### Also updated

- Examples: phone-input (demo/separated/combobox), wheel-picker form, emoji-picker form, homepage card demo. Form invalid styling now flows through `FormControl`'s `aria-invalid` instead of the old `error` prop.
- `registry.json`: `input-base` dependency replaced with `input-group` (removed for native-select).
- MDX docs: manual-install steps point at Input Group; input-base callout notes that dependents have moved off it. `input-base` itself stays published as-is.

## Verification

- `tsc --noEmit` clean; eslint 0 errors (9 pre-existing warnings in untouched files); prettier applied.
- Verified in the browser on all affected docs pages + homepage: groups measure 32px (h-8), the phone-input 4px height mismatch between input and country select is gone, segments/clear/trigger/toggle addons render correctly, zero console errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)