### PR TITLE
docs(examples): decouple form demos from react-hook-form

### DIFF
--- a/apps/v4/content/docs/components/bprogress/next.mdx
+++ b/apps/v4/content/docs/components/bprogress/next.mdx
@@ -26,7 +26,7 @@ npx shadcn@latest add junwen-k/ui-x/bprogress-provider-next-app
   Wrap your root layout with the `<BProgressProvider />` component:
 </Step>
 
-```tsx title="app/layout.tsx" {1,8}
+```tsx title="app/layout.tsx" showLineNumbers {1,8}
 import { BProgressProvider } from "@/components/bprogress-provider";
 
 export default function RootLayout({ children }: RootLayoutProps) {
@@ -65,7 +65,7 @@ npm install @bprogress/next
   Wrap your root layout with the `<BProgressProvider />` component:
 </Step>
 
-```tsx title="app/layout.tsx" {1,8}
+```tsx title="app/layout.tsx" showLineNumbers {1,8}
 import { BProgressProvider } from "@/components/bprogress-provider";
 
 export default function RootLayout({ children }: RootLayoutProps) {
@@ -109,7 +109,7 @@ npx shadcn@latest add junwen-k/ui-x/bprogress-provider-next-pages
   Wrap your root layout with the `<BProgressProvider />` component:
 </Step>
 
-```tsx title="pages/_app.tsx" {1,5,7}
+```tsx title="pages/_app.tsx" showLineNumbers {1,5,7}
 import { BProgressProvider } from "@/components/bprogress-provider";
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -145,7 +145,7 @@ npm install @bprogress/next
   Wrap your root layout with the `<BProgressProvider />` component:
 </Step>
 
-```tsx title="pages/_app.tsx" {1,5,7}
+```tsx title="pages/_app.tsx" showLineNumbers {1,5,7}
 import { BProgressProvider } from "@/components/bprogress-provider";
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/apps/v4/content/docs/components/confirmer.mdx
+++ b/apps/v4/content/docs/components/confirmer.mdx
@@ -33,7 +33,7 @@ npx shadcn@latest add junwen-k/ui-x/confirmer
   Add the `<Confirmer />` component.
 </Step>
 
-```tsx title="app/layout.tsx" {1,9}
+```tsx title="app/layout.tsx" showLineNumbers {1,9}
 import { Confirmer } from "@/components/ui/confirmer";
 
 export default function RootLayout({ children }) {
@@ -83,7 +83,7 @@ See installation instructions for the [AlertDialog](/docs/components/alert-dialo
   Add the `<Confirmer />` component.
 </Step>
 
-```tsx title="app/layout.tsx" {1,9}
+```tsx title="app/layout.tsx" showLineNumbers {1,9}
 import { Confirmer } from "@/components/ui/confirmer";
 
 export default function RootLayout({ children }) {

--- a/apps/v4/content/docs/components/phone-input.mdx
+++ b/apps/v4/content/docs/components/phone-input.mdx
@@ -91,6 +91,4 @@ import { PhoneInput } from "@/components/ui/phone-input";
 
 ### Form
 
-You can use `parsePhoneNumber` to retrieve additional information about the phone number, such as country, national number, and more.
-
 <ComponentPreview name="phone-input-form" />

--- a/apps/v4/content/docs/utilities/sortable.mdx
+++ b/apps/v4/content/docs/utilities/sortable.mdx
@@ -102,28 +102,6 @@ import {
 
 <ComponentPreview name="sortable-form" />
 
-<Callout className="mt-4">
-
-**Tip**: When working with database records, items typically include their own `id` field. To prevent conflicts with [`useFieldArray`](https://react-hook-form.com/docs/usefieldarray)'s generated IDs:
-
-1. Use `keyName` prop in `useFieldArray` to specify another name for the temporary ID (e.g., `_id`).
-
-   ```tsx
-   const { fields, move } = useFieldArray({
-     control: form.control,
-     name: "items",
-     keyName: "_id",
-   });
-   ```
-
-2. Pass the temporary IDs to `<SortableList />` or `<SortableGrid />`'s `items` prop to maintain the correct sort order during reordering.
-
-   ```tsx
-   <SortableList items={fields.map((field) => field._id)} />
-   ```
-
-</Callout>
-
 ### Virtualized
 
 <ComponentPreview name="virtualizer-sortable" />

--- a/apps/v4/public/llms.txt
+++ b/apps/v4/public/llms.txt
@@ -1,0 +1,43 @@
+# junwen-k/ui-x
+
+> junwen-k/ui-x is a set of beautifully designed components that you can copy and paste into your apps, based on shadcn/ui. It is built with TypeScript, Tailwind CSS, and Base UI primitives. Components are installed and managed with the shadcn CLI through the junwen-k/ui-x registry. Works with your favorite frameworks and AI models. Open Source. Open Code.
+
+## Overview
+
+- [Introduction](https://ui-x.junwen-k.dev/docs): What junwen-k/ui-x is and how it extends shadcn/ui.
+- [Installation](https://ui-x.junwen-k.dev/docs/installation): How to install dependencies and structure your app.
+- [Changelog](https://ui-x.junwen-k.dev/docs/changelog): Latest updates and announcements.
+
+## Primitives
+
+- [Date Time Field](https://ui-x.junwen-k.dev/docs/primitives/date-time-field): Date Time Field allows user to enter date and time value.
+- [Date Time Range Field](https://ui-x.junwen-k.dev/docs/primitives/date-time-range-field): Date Time Range Field allows user to enter date and time value for a range of dates.
+- [Date Picker](https://ui-x.junwen-k.dev/docs/primitives/date-picker): An unstyled date picker component.
+- [Dropzone](https://ui-x.junwen-k.dev/docs/primitives/dropzone): A dropzone is an area into which one or multiple objects can be dragged and dropped.
+- [Password Input](https://ui-x.junwen-k.dev/docs/primitives/password-input): Password Input provides a way for the user to securely enter a password, with the ability to toggle the visibility of the password.
+- [Phone Input](https://ui-x.junwen-k.dev/docs/primitives/phone-input): Phone Input allows user to enter phone number in E.164 format.
+
+## Utilities
+
+- [Sortable](https://ui-x.junwen-k.dev/docs/utilities/sortable): Sortable provides a way to sort items in a list or grid.
+- [Virtualizer](https://ui-x.junwen-k.dev/docs/utilities/virtualizer): A virtualizer component that allows you to efficiently render large lists and tabular data.
+
+## Components
+
+- [Badge Group](https://ui-x.junwen-k.dev/docs/components/badge-group): A badge group is a focusable list of labels, categories, keywords, filters, or other items, with support for keyboard navigation, selection, and removal.
+- [BProgress](https://ui-x.junwen-k.dev/docs/components/bprogress): A smooth progress bar for page transitions. BProgress is an upgraded version of NProgress, a minimal progress bar that provides visual feedback during page loads and navigation.
+- [BProgress - Next.js](https://ui-x.junwen-k.dev/docs/components/bprogress/next): Integrating BProgress in your Next.js app.
+- [Confirmer](https://ui-x.junwen-k.dev/docs/components/confirmer): Imperative confirm dialog implementation.
+- [Date Field](https://ui-x.junwen-k.dev/docs/components/date-field): Date Field allows user to enter date value.
+- [Date Time Field](https://ui-x.junwen-k.dev/docs/components/date-time-field): Date Time Field allows user to enter date and time value.
+- [Date Time Range Field](https://ui-x.junwen-k.dev/docs/components/date-time-range-field): Date Time Range Field allows user to enter date and time value for a range of dates.
+- [Date Picker](https://ui-x.junwen-k.dev/docs/components/date-picker): A date picker component lets users select a date.
+- [Emoji Picker](https://ui-x.junwen-k.dev/docs/components/emoji-picker): A emoji picker is a component that allows users to select an emoji from a list of emojis.
+- [Description List](https://ui-x.junwen-k.dev/docs/components/description-list): A description list, with terms and descriptions.
+- [Dropzone](https://ui-x.junwen-k.dev/docs/components/dropzone): A dropzone is an area into which one or multiple objects can be dragged and dropped.
+- [Password Input](https://ui-x.junwen-k.dev/docs/components/password-input): Password Input provides a way for the user to securely enter a password, with the ability to toggle the visibility of the password.
+- [Phone Input](https://ui-x.junwen-k.dev/docs/components/phone-input): Phone Input allows user to enter phone number in E.164 format.
+- [Time Field](https://ui-x.junwen-k.dev/docs/components/time-field): Time Field allows user to enter time value.
+- [Time](https://ui-x.junwen-k.dev/docs/components/time): Displays a specific time (or datetime).
+- [Timeline](https://ui-x.junwen-k.dev/docs/components/timeline): Timeline displays a list of events in chronological order.
+- [Wheel Picker](https://ui-x.junwen-k.dev/docs/components/wheel-picker): iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support.

--- a/apps/v4/src/components/command-menu.tsx
+++ b/apps/v4/src/components/command-menu.tsx
@@ -29,7 +29,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { useMutationObserver } from "@/hooks/use-mutation-observer";
 import { REGISTRY_NAMES } from "@/lib/docs";
-import { getPagesFromFolder } from "@/lib/page-tree";
+import { getOwnSectionsFromFolder } from "@/lib/page-tree";
 import { cn } from "@/lib/utils";
 
 export function CommandMenu({
@@ -163,7 +163,9 @@ export function CommandMenu({
         return null;
       }
 
-      const pages = getPagesFromFolder(group);
+      const pages = getOwnSectionsFromFolder(group).flatMap(
+        (section) => section.pages,
+      );
 
       if (pages.length === 0) {
         return null;

--- a/apps/v4/src/components/command-menu.tsx
+++ b/apps/v4/src/components/command-menu.tsx
@@ -27,7 +27,6 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
-import { siteConfig } from "@/config/site";
 import { useMutationObserver } from "@/hooks/use-mutation-observer";
 import { REGISTRY_NAMES } from "@/lib/docs";
 import { getPagesFromFolder } from "@/lib/page-tree";
@@ -110,9 +109,7 @@ export function CommandMenu({
 
       if (REGISTRY_NAMES.has(componentName)) {
         setSelectedType("component");
-        setCopyPayload(
-          `npx shadcn@latest add ${siteConfig.url}/r/${componentName}.json`,
-        );
+        setCopyPayload(`npx shadcn@latest add junwen-k/ui-x/${componentName}`);
       } else {
         setSelectedType("page");
         setCopyPayload("");
@@ -197,7 +194,7 @@ export function CommandMenu({
                 }}
               >
                 {isComponent ? (
-                  <div className="aspect-square size-4 rounded-full border border-dashed border-muted-foreground" />
+                  <div className="border-muted-foreground aspect-square size-4 rounded-full border border-dashed" />
                 ) : (
                   <ArrowRightIcon />
                 )}
@@ -244,7 +241,7 @@ export function CommandMenu({
           <Button
             variant="outline"
             className={cn(
-              "relative h-8 w-full justify-start rounded-lg border-none bg-muted pl-3 text-foreground shadow-none transition-colors hover:bg-muted/50 md:w-48 lg:w-40 xl:w-64 dark:bg-card",
+              "bg-muted text-foreground hover:bg-muted/50 dark:bg-card relative h-8 w-full justify-start rounded-lg border-none pl-3 shadow-none transition-colors md:w-48 lg:w-40 xl:w-64",
             )}
             {...props}
           >
@@ -271,24 +268,28 @@ export function CommandMenu({
             />
             {query.isLoading && (
               <div className="pointer-events-none absolute top-1/2 right-3 z-10 flex -translate-y-1/2 items-center justify-center">
-                <Icons.spinner className="size-4 animate-spin text-muted-foreground" />
+                <Icons.spinner className="text-muted-foreground size-4 animate-spin" />
               </div>
             )}
           </div>
           <CommandList className="no-scrollbar min-h-80 scroll-pt-2 scroll-pb-1.5">
-            <CommandEmpty className="py-12 text-center text-sm text-muted-foreground">
+            <CommandEmpty className="text-muted-foreground py-12 text-center text-sm">
               {query.isLoading ? "Searching..." : "No results found."}
             </CommandEmpty>
             {navItemsSection}
             {renderDelayedGroups ? (
               <>
                 {pageGroupsSection}
-                <SearchResults setOpen={setOpen} query={query} search={search} />
+                <SearchResults
+                  setOpen={setOpen}
+                  query={query}
+                  search={search}
+                />
               </>
             ) : null}
           </CommandList>
         </Command>
-        <div className="absolute inset-x-0 bottom-0 z-20 flex h-10 items-center gap-2 rounded-b-xl border-t border-t-neutral-100 bg-neutral-50 px-4 text-xs font-medium text-muted-foreground dark:border-t-neutral-700 dark:bg-neutral-800">
+        <div className="text-muted-foreground absolute inset-x-0 bottom-0 z-20 flex h-10 items-center gap-2 rounded-b-xl border-t border-t-neutral-100 bg-neutral-50 px-4 text-xs font-medium dark:border-t-neutral-700 dark:bg-neutral-800">
           <div className="flex items-center gap-2">
             <CommandMenuKbd>
               <CornerDownLeftIcon />
@@ -341,7 +342,7 @@ function CommandMenuItem({
     <CommandItem
       ref={ref}
       className={cn(
-        "h-9 rounded-md border border-transparent px-3! font-medium data-[selected=true]:border-input data-[selected=true]:bg-input/50",
+        "data-[selected=true]:border-input data-[selected=true]:bg-input/50 h-9 rounded-md border border-transparent px-3! font-medium",
         className,
       )}
       {...props}
@@ -355,7 +356,7 @@ function CommandMenuKbd({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       className={cn(
-        "pointer-events-none flex h-5 items-center justify-center gap-1 rounded border bg-background px-1 font-sans text-[0.7rem] font-medium text-muted-foreground select-none [&_svg:not([class*='size-'])]:size-3",
+        "bg-background text-muted-foreground pointer-events-none flex h-5 items-center justify-center gap-1 rounded border px-1 font-sans text-[0.7rem] font-medium select-none [&_svg:not([class*='size-'])]:size-3",
         className,
       )}
       {...props}
@@ -415,7 +416,7 @@ function SearchResults({
               router.push(item.url);
               setOpen(false);
             }}
-            className="h-9 rounded-md border border-transparent px-3! font-normal data-[selected=true]:border-input data-[selected=true]:bg-input/50"
+            className="data-[selected=true]:border-input data-[selected=true]:bg-input/50 h-9 rounded-md border border-transparent px-3! font-normal"
             keywords={[item.content]}
             value={`${item.content} ${item.type}`}
           >
@@ -439,7 +440,7 @@ function CommandMenuDialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-[15%] left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 gap-4 bg-background duration-100 outline-none sm:max-w-lg",
+          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 bg-background fixed top-[15%] left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 gap-4 duration-100 outline-none sm:max-w-lg",
           className,
         )}
         {...props}

--- a/apps/v4/src/components/examples/badge-group-form.tsx
+++ b/apps/v4/src/components/examples/badge-group-form.tsx
@@ -1,24 +1,18 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
+import * as React from "react";
 
 import { Button } from "@/components/ui/button";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { BadgeGroup, BadgeGroupItem } from "@/registry/new-york/ui/badge-group";
-
-const FormSchema = z.object({
-  options: z
-    .object({
-      label: z.string(),
-      value: z.string(),
-    })
-    .array(),
-  selected: z.string().array(),
-});
 
 const flavours = [
   {
@@ -40,70 +34,51 @@ const flavours = [
 ];
 
 export default function BadgeGroupForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      options: flavours,
-      selected: flavours.map((option) => option.value).slice(0, 2),
-    },
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
-  const options = form.watch("options");
+  const [options, setOptions] = React.useState(flavours);
+  const [selected, setSelected] = React.useState(
+    flavours.map((option) => option.value).slice(0, 2),
+  );
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-      <Controller
-        control={form.control}
-        name="selected"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel>Ice cream flavor</FieldLabel>
-            <BadgeGroup
-              type="multiple"
-              value={field.value}
-              onValueChange={field.onChange}
-              onRemove={(value) => {
-                form.setValue(
-                  "options",
-                  options.filter((option) => !value.includes(option.value)),
-                );
-                field.onChange(
-                  field.value.filter((selected) => !value.includes(selected)),
-                );
-              }}
-              aria-invalid={fieldState.invalid}
-            >
-              {options.map((option) => (
-                <BadgeGroupItem key={option.value} value={option.value}>
-                  {option.label}
-                </BadgeGroupItem>
-              ))}
-            </BadgeGroup>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Customize your order</CardTitle>
+        <CardDescription>
+          Tell us how you would like your ice cream.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Ice cream flavor</FieldLabel>
+          <BadgeGroup
+            type="multiple"
+            value={selected}
+            onValueChange={setSelected}
+            onRemove={(value) => {
+              setOptions((options) =>
+                options.filter((option) => !value.includes(option.value)),
+              );
+              setSelected((selected) =>
+                selected.filter((flavour) => !value.includes(flavour)),
+              );
+            }}
+          >
+            {options.map((option) => (
+              <BadgeGroupItem key={option.value} value={option.value}>
+                {option.label}
+              </BadgeGroupItem>
+            ))}
+          </BadgeGroup>
+          <FieldDescription>
+            Select your favorite flavors, or remove the ones you dislike.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/date-field-form.tsx
+++ b/apps/v4/src/components/examples/date-field-form.tsx
@@ -1,18 +1,13 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   DateField,
   DateFieldDays,
@@ -21,63 +16,33 @@ import {
   DateFieldYears,
 } from "@/registry/new-york/ui/date-field";
 
-const FormSchema = z.object({
-  dob: z.date({
-    required_error: "A date of birth is required.",
-  }),
-});
-
 export default function DateFieldForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="dob"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel>Date of birth</FieldLabel>
-            <DateField
-              value={field.value ?? null}
-              onValueChange={field.onChange}
-            >
-              <DateFieldDays aria-invalid={fieldState.invalid} />
-              <DateFieldSeparator />
-              <DateFieldMonths />
-              <DateFieldSeparator />
-              <DateFieldYears />
-            </DateField>
-            <FieldDescription>
-              Your date of birth is used to calculate your age.
-            </FieldDescription>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Personal information</CardTitle>
+        <CardDescription>Tell us a little bit about yourself.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Date of birth</FieldLabel>
+          <DateField>
+            <DateFieldDays />
+            <DateFieldSeparator />
+            <DateFieldMonths />
+            <DateFieldSeparator />
+            <DateFieldYears />
+          </DateField>
+          <FieldDescription>
+            Your date of birth is used to calculate your age.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/date-picker-form.tsx
+++ b/apps/v4/src/components/examples/date-picker-form.tsx
@@ -1,19 +1,13 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import { DateRange } from "react-day-picker";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   DatePicker,
   DatePickerCalendar,
@@ -21,81 +15,34 @@ import {
   DatePickerInput,
 } from "@/registry/new-york/ui/date-picker";
 
-const FormSchema = z.object({
-  eventPeriod: z
-    .object(
-      {
-        from: z.date().optional(),
-        to: z.date().optional(),
-      },
-      {
-        required_error: "Event period is required.",
-      },
-    )
-    .superRefine((data, ctx) => {
-      if (!data.from || !data.to) {
-        ctx.addIssue({
-          message: "Event period is required.",
-          code: "custom",
-        });
-      }
-    }),
-});
-
 export default function DatePickerForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="eventPeriod"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel>Event period</FieldLabel>
-            <DatePicker
-              mode="range"
-              value={(field.value ?? null) as DateRange | null}
-              onValueChange={field.onChange}
-            >
-              <DatePickerInput
-                className="w-[280px]"
-                aria-invalid={fieldState.invalid}
-              />
-              <DatePickerContent>
-                <DatePickerCalendar hideNavigation captionLayout="dropdown" />
-              </DatePickerContent>
-            </DatePicker>
-            <FieldDescription>
-              Schedule your event by selecting a start and end date.
-            </FieldDescription>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Schedule your event</CardTitle>
+        <CardDescription>
+          Let attendees know when your event takes place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Event period</FieldLabel>
+          <DatePicker mode="range">
+            <DatePickerInput className="w-full" />
+            <DatePickerContent>
+              <DatePickerCalendar hideNavigation captionLayout="dropdown" />
+            </DatePickerContent>
+          </DatePicker>
+          <FieldDescription>
+            Schedule your event by selecting a start and end date.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/date-time-field-form.tsx
+++ b/apps/v4/src/components/examples/date-time-field-form.tsx
@@ -1,18 +1,13 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   DateTimeField,
   DateTimeFieldAmPm,
@@ -25,70 +20,42 @@ import {
   DateTimeFieldYears,
 } from "@/registry/new-york/ui/date-time-field";
 
-const FormSchema = z.object({
-  eventDate: z.date({
-    required_error: "Event date is required.",
-  }),
-});
-
 export default function DateTimeFieldForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="eventDate"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel>Event date</FieldLabel>
-            <DateTimeField
-              value={field.value ?? null}
-              onValueChange={field.onChange}
-            >
-              <DateTimeFieldDays aria-invalid={fieldState.invalid} />
-              <DateTimeFieldSeparator>/</DateTimeFieldSeparator>
-              <DateTimeFieldMonths />
-              <DateTimeFieldSeparator>/</DateTimeFieldSeparator>
-              <DateTimeFieldYears />
-              <DateTimeFieldSeparator>·</DateTimeFieldSeparator>
-              <DateTimeFieldHours />
-              <DateTimeFieldSeparator>:</DateTimeFieldSeparator>
-              <DateTimeFieldMinutes />
-              <DateTimeFieldSeparator>:</DateTimeFieldSeparator>
-              <DateTimeFieldSeconds />
-              <DateTimeFieldAmPm />
-            </DateTimeField>
-            <FieldDescription>
-              Schedule your event by selecting a date and time.
-            </FieldDescription>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Schedule your event</CardTitle>
+        <CardDescription>
+          Let attendees know when your event takes place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Event date</FieldLabel>
+          <DateTimeField>
+            <DateTimeFieldDays />
+            <DateTimeFieldSeparator>/</DateTimeFieldSeparator>
+            <DateTimeFieldMonths />
+            <DateTimeFieldSeparator>/</DateTimeFieldSeparator>
+            <DateTimeFieldYears />
+            <DateTimeFieldSeparator>·</DateTimeFieldSeparator>
+            <DateTimeFieldHours />
+            <DateTimeFieldSeparator>:</DateTimeFieldSeparator>
+            <DateTimeFieldMinutes />
+            <DateTimeFieldSeparator>:</DateTimeFieldSeparator>
+            <DateTimeFieldSeconds />
+            <DateTimeFieldAmPm />
+          </DateTimeField>
+          <FieldDescription>
+            Schedule your event by selecting a date and time.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/date-time-range-field-form.tsx
+++ b/apps/v4/src/components/examples/date-time-range-field-form.tsx
@@ -1,19 +1,13 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import { DateRange } from "react-day-picker";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   DateTimeRangeField,
   DateTimeRangeFieldDays,
@@ -24,88 +18,45 @@ import {
   DateTimeRangeFieldYears,
 } from "@/registry/new-york/ui/date-time-range-field";
 
-const FormSchema = z.object({
-  eventPeriod: z
-    .object(
-      {
-        from: z.date().optional(),
-        to: z.date().optional(),
-      },
-      {
-        required_error: "Event period is required.",
-      },
-    )
-    .superRefine((data, ctx) => {
-      if (!data.from || !data.to) {
-        ctx.addIssue({
-          message: "Event period is required.",
-          code: "custom",
-        });
-      }
-    }),
-});
-
 export default function DateTimeRangeFieldForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="eventPeriod"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel>Event period</FieldLabel>
-            <DateTimeRangeField
-              value={(field.value ?? null) as DateRange | null}
-              onValueChange={field.onChange}
-            >
-              <DateTimeRangeFieldFrom>
-                <DateTimeRangeFieldDays aria-invalid={fieldState.invalid} />
-                <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
-                <DateTimeRangeFieldMonths />
-                <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
-                <DateTimeRangeFieldYears />
-              </DateTimeRangeFieldFrom>
-              <DateTimeRangeFieldSeparator>-</DateTimeRangeFieldSeparator>
-              <DateTimeRangeFieldTo>
-                <DateTimeRangeFieldDays />
-                <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
-                <DateTimeRangeFieldMonths />
-                <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
-                <DateTimeRangeFieldYears />
-              </DateTimeRangeFieldTo>
-            </DateTimeRangeField>
-            <FieldDescription>
-              Schedule your event by selecting a start and end date.
-            </FieldDescription>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Schedule your event</CardTitle>
+        <CardDescription>
+          Let attendees know when your event takes place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Event period</FieldLabel>
+          <DateTimeRangeField>
+            <DateTimeRangeFieldFrom>
+              <DateTimeRangeFieldDays />
+              <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
+              <DateTimeRangeFieldMonths />
+              <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
+              <DateTimeRangeFieldYears />
+            </DateTimeRangeFieldFrom>
+            <DateTimeRangeFieldSeparator>-</DateTimeRangeFieldSeparator>
+            <DateTimeRangeFieldTo>
+              <DateTimeRangeFieldDays />
+              <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
+              <DateTimeRangeFieldMonths />
+              <DateTimeRangeFieldSeparator>/</DateTimeRangeFieldSeparator>
+              <DateTimeRangeFieldYears />
+            </DateTimeRangeFieldTo>
+          </DateTimeRangeField>
+          <FieldDescription>
+            Schedule your event by selecting a start and end date.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/dropzone-form.tsx
+++ b/apps/v4/src/components/examples/dropzone-form.tsx
@@ -1,21 +1,11 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
 import { FileIcon, XIcon } from "lucide-react";
 import prettyBytes from "pretty-bytes";
+import * as React from "react";
 import { ErrorCode } from "react-dropzone";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
 import { toast } from "sonner";
-import { z } from "zod";
 
-import { Button } from "@/components/ui/button";
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
 import {
   Attachment,
   AttachmentAction,
@@ -25,6 +15,16 @@ import {
   AttachmentMedia,
   AttachmentTitle,
 } from "@/components/ui/attachment";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   Dropzone,
   DropzoneDescription,
@@ -37,139 +37,94 @@ import {
 // 1 MB
 const MAX_FILE_SIZE = 1e6;
 
-const FormSchema = z.object({
-  files: z
-    .array(
-      z.object({
-        file: z
-          .instanceof(File)
-          .refine(
-            (file) => file.size <= MAX_FILE_SIZE,
-            "File exceed max file size",
-          ),
-      }),
-    )
-    .min(1, { message: "Minimum one file is required." }),
-});
-
 export default function DropzoneForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      files: [],
-    },
-  });
-  const { fields, append, remove } = useFieldArray({
-    control: form.control,
-    name: "files",
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
+  const [files, setFiles] = React.useState<File[]>([]);
 
   return (
-    <form
-      onSubmit={form.handleSubmit(onSubmit)}
-      className="w-[40rem] space-y-6"
-    >
-      <Dropzone
-        maxSize={MAX_FILE_SIZE}
-        onDropAccepted={(acceptedFiles) =>
-          append(acceptedFiles.map((file) => ({ file })))
-        }
-        onDropRejected={(fileRejections) => {
-          fileRejections.forEach((fileRejection) => {
-            if (
-              fileRejection.errors.some(
-                (err) => err.code === ErrorCode.FileTooLarge,
-              )
-            ) {
-              toast.error("File size too large.", {
-                description: `File '${fileRejection.file.name}' is too large.`,
-              });
-            }
-          });
-        }}
-      >
-        {({ maxSize }) => (
-          <Controller
-            control={form.control}
-            name="files"
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>File upload</FieldLabel>
-                <DropzoneZone className="flex justify-center">
-                  <DropzoneInput
-                    id={field.name}
-                    disabled={field.disabled}
-                    name={field.name}
-                    onBlur={field.onBlur}
-                    ref={field.ref}
-                    aria-invalid={fieldState.invalid}
-                  />
-                  <div className="flex items-center gap-6">
-                    <DropzoneUploadIcon />
-                    <div className="grid gap-0.5">
-                      <DropzoneTitle>Browse to upload your file</DropzoneTitle>
-                      <DropzoneDescription>
-                        {`Maximum file size: ${prettyBytes(maxSize ?? 0)}`}
-                      </DropzoneDescription>
-                    </div>
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Upload your files</CardTitle>
+        <CardDescription>
+          Attach the documents you would like to share.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-6">
+        <Dropzone
+          maxSize={MAX_FILE_SIZE}
+          onDropAccepted={(acceptedFiles) =>
+            setFiles((files) => [...files, ...acceptedFiles])
+          }
+          onDropRejected={(fileRejections) => {
+            fileRejections.forEach((fileRejection) => {
+              if (
+                fileRejection.errors.some(
+                  (err) => err.code === ErrorCode.FileTooLarge,
+                )
+              ) {
+                toast.error("File size too large.", {
+                  description: `File '${fileRejection.file.name}' is too large.`,
+                });
+              }
+            });
+          }}
+        >
+          {({ maxSize }) => (
+            <Field>
+              <FieldLabel htmlFor="dropzone-form-files">File upload</FieldLabel>
+              <DropzoneZone className="flex justify-center">
+                <DropzoneInput id="dropzone-form-files" />
+                <div className="flex items-center gap-6">
+                  <DropzoneUploadIcon />
+                  <div className="grid gap-0.5">
+                    <DropzoneTitle>Browse to upload your file</DropzoneTitle>
+                    <DropzoneDescription>
+                      {`Maximum file size: ${prettyBytes(maxSize ?? 0)}`}
+                    </DropzoneDescription>
                   </div>
-                </DropzoneZone>
-                <FieldDescription>Drag and drop is supported.</FieldDescription>
-                {fieldState.invalid && (
-                  <FieldError errors={[fieldState.error]} />
-                )}
-              </Field>
-            )}
-          />
-        )}
-      </Dropzone>
-      {!!fields.length && (
-        <div className="grid gap-4">
-          <h6 className="leading-none font-semibold tracking-tight">{`Files (${fields.length})`}</h6>
-          <div className="grid gap-2">
-            {fields.map((field, index) => (
-              <Attachment key={field.id} className="w-full">
-                <AttachmentMedia>
-                  <FileIcon />
-                </AttachmentMedia>
-                <AttachmentContent>
-                  <AttachmentTitle>{field.file.name}</AttachmentTitle>
-                  <AttachmentDescription>
-                    {prettyBytes(field.file.size)}
-                  </AttachmentDescription>
-                </AttachmentContent>
-                <AttachmentActions>
-                  <AttachmentAction onClick={() => remove(index)}>
-                    <XIcon />
-                    <span className="sr-only">Remove</span>
-                  </AttachmentAction>
-                </AttachmentActions>
-              </Attachment>
-            ))}
+                </div>
+              </DropzoneZone>
+              <FieldDescription>Drag and drop is supported.</FieldDescription>
+            </Field>
+          )}
+        </Dropzone>
+        {!!files.length && (
+          <div className="grid gap-4">
+            <h6 className="leading-none font-semibold tracking-tight">{`Files (${files.length})`}</h6>
+            <div className="grid gap-2">
+              {files.map((file, index) => (
+                <Attachment key={index} className="w-full">
+                  <AttachmentMedia>
+                    <FileIcon />
+                  </AttachmentMedia>
+                  <AttachmentContent>
+                    <AttachmentTitle>{file.name}</AttachmentTitle>
+                    <AttachmentDescription>
+                      {prettyBytes(file.size)}
+                    </AttachmentDescription>
+                  </AttachmentContent>
+                  <AttachmentActions>
+                    <AttachmentAction
+                      onClick={() =>
+                        setFiles((files) =>
+                          files.filter((_, fileIndex) => fileIndex !== index),
+                        )
+                      }
+                    >
+                      <XIcon />
+                      <span className="sr-only">Remove</span>
+                    </AttachmentAction>
+                  </AttachmentActions>
+                </Attachment>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
-      <Button type="submit">Submit</Button>
-    </form>
+        )}
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/emoji-picker-form.tsx
+++ b/apps/v4/src/components/examples/emoji-picker-form.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
 import { SmilePlusIcon } from "lucide-react";
 import * as React from "react";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   InputGroup,
   InputGroupAddon,
@@ -28,120 +31,82 @@ import {
   EmojiPickerSearch,
 } from "@/registry/new-york/ui/emoji-picker";
 
-const FormSchema = z.object({
-  message: z.string().min(1, { message: "Message is required" }),
-});
-
 export default function EmojiPickerForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      message: "",
-    },
-  });
-
+  const [message, setMessage] = React.useState("");
   const [open, setOpen] = React.useState(false);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-      <Popover open={open} onOpenChange={setOpen}>
-        <Controller
-          control={form.control}
-          name="message"
-          render={({ field, fieldState }) => (
-            <Field data-invalid={fieldState.invalid}>
-              <FieldLabel htmlFor={field.name}>Message</FieldLabel>
-              <InputGroup className="w-96">
-                <InputGroupTextarea
-                  {...field}
-                  id={field.name}
-                  ref={textareaRef}
-                  rows={3}
-                  placeholder="Type a message..."
-                  aria-invalid={fieldState.invalid}
-                />
-                <InputGroupAddon align="block-end">
-                  <PopoverTrigger
-                    render={
-                      <InputGroupButton
-                        size="icon-xs"
-                        className="ml-auto"
-                        aria-invalid={fieldState.invalid}
-                      />
-                    }
-                  >
-                    <SmilePlusIcon />
-                    <span className="sr-only">Pick emoji</span>
-                  </PopoverTrigger>
-                </InputGroupAddon>
-              </InputGroup>
-              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-            </Field>
-          )}
-        />
-        <PopoverContent className="w-fit p-0" align="end" side="bottom">
-          <Controller
-            control={form.control}
-            name="message"
-            render={({ field }) => (
-              <EmojiPicker
-                className="h-84"
-                onEmojiSelect={({ emoji }) => {
-                  const textarea = textareaRef.current;
-                  if (!textarea) {
-                    return;
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Send us a message</CardTitle>
+        <CardDescription>We would love to hear what you think.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Popover open={open} onOpenChange={setOpen}>
+          <Field>
+            <FieldLabel htmlFor="emoji-picker-form-message">Message</FieldLabel>
+            <InputGroup>
+              <InputGroupTextarea
+                id="emoji-picker-form-message"
+                ref={textareaRef}
+                rows={3}
+                placeholder="Type a message..."
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+              />
+              <InputGroupAddon align="block-end">
+                <PopoverTrigger
+                  render={
+                    <InputGroupButton size="icon-xs" className="ml-auto" />
                   }
+                >
+                  <SmilePlusIcon />
+                  <span className="sr-only">Pick emoji</span>
+                </PopoverTrigger>
+              </InputGroupAddon>
+            </InputGroup>
+            <FieldDescription>
+              Use the emoji picker to add some personality.
+            </FieldDescription>
+          </Field>
+          <PopoverContent className="w-fit p-0" align="end" side="bottom">
+            <EmojiPicker
+              className="h-84"
+              onEmojiSelect={({ emoji }) => {
+                const textarea = textareaRef.current;
+                if (!textarea) {
+                  return;
+                }
 
-                  const start = textarea.selectionStart;
-                  const end = textarea.selectionEnd;
+                const start = textarea.selectionStart;
+                const end = textarea.selectionEnd;
 
-                  field.onChange(
-                    [
-                      field.value.slice(0, start),
-                      emoji,
-                      field.value.slice(end),
-                    ].join(""),
-                  );
+                setMessage(
+                  [message.slice(0, start), emoji, message.slice(end)].join(""),
+                );
 
-                  setOpen(false);
+                setOpen(false);
 
-                  setTimeout(() => {
-                    const position = start + emoji.length;
-                    textarea.focus();
-                    textarea.setSelectionRange(position, position);
-                  });
-                }}
-              >
-                <EmojiPickerSearch />
-                <EmojiPickerContent />
-                <EmojiPickerFooter />
-              </EmojiPicker>
-            )}
-          />
-        </PopoverContent>
-      </Popover>
-      <Button type="submit">Submit</Button>
-    </form>
+                setTimeout(() => {
+                  const position = start + emoji.length;
+                  textarea.focus();
+                  textarea.setSelectionRange(position, position);
+                });
+              }}
+            >
+              <EmojiPickerSearch />
+              <EmojiPickerContent />
+              <EmojiPickerFooter />
+            </EmojiPicker>
+          </PopoverContent>
+        </Popover>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Send
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/password-input-form.tsx
+++ b/apps/v4/src/components/examples/password-input-form.tsx
@@ -1,14 +1,20 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
 import { LockKeyhole } from "lucide-react";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
 import {
   PasswordInput,
   PasswordInputAdornment,
@@ -16,96 +22,64 @@ import {
   PasswordInputInput,
 } from "@/registry/new-york/ui/password-input";
 
-const FormSchema = z
-  .object({
-    password: z.string().min(12, {
-      message: "Password must be at least 12 characters.",
-    }),
-    confirmPassword: z.string(),
-  })
-  .refine(({ password, confirmPassword }) => password === confirmPassword, {
-    message: "Passwords don't match",
-    path: ["confirmPassword"],
-  });
-
 export default function PasswordInputForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      password: "",
-      confirmPassword: "",
-    },
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-      <Controller
-        control={form.control}
-        name="password"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel htmlFor={field.name}>Password</FieldLabel>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Create your account</CardTitle>
+        <CardDescription>
+          Choose a strong password to secure your account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor="password-input-form-password">
+              Password
+            </FieldLabel>
             <PasswordInput>
               <PasswordInputAdornment>
                 <LockKeyhole />
               </PasswordInputAdornment>
               <PasswordInputInput
-                id={field.name}
+                id="password-input-form-password"
                 autoComplete="new-password"
                 placeholder="Password"
-                aria-invalid={fieldState.invalid}
-                {...field}
+                required
+                minLength={12}
               />
               <PasswordInputAdornmentToggle />
             </PasswordInput>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            <FieldDescription>
+              Must be at least 12 characters long.
+            </FieldDescription>
           </Field>
-        )}
-      />
-      <Controller
-        control={form.control}
-        name="confirmPassword"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel htmlFor={field.name}>Confirm Password</FieldLabel>
+          <Field>
+            <FieldLabel htmlFor="password-input-form-confirm-password">
+              Confirm Password
+            </FieldLabel>
             <PasswordInput>
               <PasswordInputAdornment>
                 <LockKeyhole />
               </PasswordInputAdornment>
               <PasswordInputInput
-                id={field.name}
+                id="password-input-form-confirm-password"
                 autoComplete="new-password"
                 placeholder="Confirm Password"
-                aria-invalid={fieldState.invalid}
-                {...field}
+                required
+                minLength={12}
               />
               <PasswordInputAdornmentToggle />
             </PasswordInput>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            <FieldDescription>Please confirm your password.</FieldDescription>
           </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+        </FieldGroup>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Create account
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/phone-input-form.tsx
+++ b/apps/v4/src/components/examples/phone-input-form.tsx
@@ -1,106 +1,49 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import * as React from "react";
-import { Controller, useForm } from "react-hook-form";
-import { parsePhoneNumber } from "react-phone-number-input";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   PhoneInput,
   PhoneInputInput,
-  Value,
 } from "@/registry/new-york/ui/phone-input";
 
-// Based on https://github.com/colinhacks/zod/issues/3378#issuecomment-2067591844.
-const zPhoneNumber = z.custom<Value>().transform((value, ctx) => {
-  const phoneNumber = parsePhoneNumber(value);
-
-  if (!phoneNumber?.isValid()) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Invalid phone number",
-    });
-    return z.NEVER;
-  }
-
-  return phoneNumber.number;
-});
-
-const FormSchema = z.object({
-  phoneNumber: zPhoneNumber,
-});
-
 export default function PhoneInputForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      phoneNumber: "",
-    },
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(
-      JSON.stringify(
-        {
-          ...data,
-          parsed: parsePhoneNumber(data.phoneNumber),
-        },
-        null,
-        2,
-      ),
-      {
-        lang: "json",
-        theme: "github-dark-dimmed",
-        colorReplacements: {
-          "#22272e": "var(--color-zinc-900)",
-        },
-      },
-    );
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="phoneNumber"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel htmlFor={field.name}>Phone number</FieldLabel>
-            <PhoneInput value={field.value} onValueChange={field.onChange}>
-              <PhoneInputInput
-                id={field.name}
-                placeholder="Phone number"
-                aria-invalid={fieldState.invalid}
-              />
-            </PhoneInput>
-            <FieldDescription>
-              Your phone number is used to contact you.
-            </FieldDescription>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Contact information</CardTitle>
+        <CardDescription>
+          How can we reach you if we need to follow up?
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel htmlFor="phone-input-form-phone-number">
+            Phone number
+          </FieldLabel>
+          <PhoneInput>
+            <PhoneInputInput
+              id="phone-input-form-phone-number"
+              placeholder="Phone number"
+              required
+            />
+          </PhoneInput>
+          <FieldDescription>
+            Your phone number is used to contact you.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/sortable-form.tsx
+++ b/apps/v4/src/components/examples/sortable-form.tsx
@@ -4,16 +4,19 @@ import {
   restrictToParentElement,
   restrictToVerticalAxis,
 } from "@dnd-kit/modifiers";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { arrayMove } from "@dnd-kit/sortable";
 import { GripVertical, Pencil, PlusCircle, Trash2 } from "lucide-react";
 import * as React from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Dialog,
   DialogClose,
@@ -24,7 +27,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -100,18 +103,13 @@ function Item({
   );
 }
 
-const EditItemFormDialogSchema = z.object({
-  title: z.string().min(1, { message: "Title is required" }),
-  description: z.string().min(1, { message: "Description is required" }),
-});
-
 interface EditItemFormDialogProps {
   children: React.ReactNode;
   title: React.ReactNode;
   description: React.ReactNode;
   actionText: React.ReactNode;
-  onSubmit: (data: z.infer<typeof EditItemFormDialogSchema>) => void;
-  values?: z.infer<typeof EditItemFormDialogSchema>;
+  onSubmit: (data: { title: string; description: string }) => void;
+  values?: { title: string; description: string };
 }
 
 const EditItemFormDialog = ({
@@ -122,22 +120,8 @@ const EditItemFormDialog = ({
   onSubmit,
   values,
 }: EditItemFormDialogProps) => {
+  const id = React.useId();
   const [open, setOpen] = React.useState(false);
-
-  const form = useForm<z.infer<typeof EditItemFormDialogSchema>>({
-    resolver: zodResolver(EditItemFormDialogSchema),
-    values,
-    defaultValues: {
-      title: "",
-      description: "",
-    },
-  });
-
-  const handleSubmit = (data: z.infer<typeof EditItemFormDialogSchema>) => {
-    onSubmit(data);
-    setOpen(false);
-    form.reset();
-  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -148,7 +132,12 @@ const EditItemFormDialog = ({
             event.stopPropagation();
             event.preventDefault();
 
-            form.handleSubmit(handleSubmit)(event);
+            const formData = new FormData(event.currentTarget);
+            onSubmit({
+              title: formData.get("title") as string,
+              description: formData.get("description") as string,
+            });
+            setOpen(false);
           }}
         >
           <DialogHeader>
@@ -156,40 +145,24 @@ const EditItemFormDialog = ({
             <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
-            <Controller
-              control={form.control}
-              name="title"
-              render={({ field, fieldState }) => (
-                <Field data-invalid={fieldState.invalid}>
-                  <FieldLabel htmlFor={field.name}>Title</FieldLabel>
-                  <Input
-                    id={field.name}
-                    aria-invalid={fieldState.invalid}
-                    {...field}
-                  />
-                  {fieldState.invalid && (
-                    <FieldError errors={[fieldState.error]} />
-                  )}
-                </Field>
-              )}
-            />
-            <Controller
-              control={form.control}
-              name="description"
-              render={({ field, fieldState }) => (
-                <Field data-invalid={fieldState.invalid}>
-                  <FieldLabel htmlFor={field.name}>Description</FieldLabel>
-                  <Textarea
-                    id={field.name}
-                    aria-invalid={fieldState.invalid}
-                    {...field}
-                  />
-                  {fieldState.invalid && (
-                    <FieldError errors={[fieldState.error]} />
-                  )}
-                </Field>
-              )}
-            />
+            <Field>
+              <FieldLabel htmlFor={`${id}-title`}>Title</FieldLabel>
+              <Input
+                id={`${id}-title`}
+                name="title"
+                defaultValue={values?.title}
+                required
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor={`${id}-description`}>Description</FieldLabel>
+              <Textarea
+                id={`${id}-description`}
+                name="description"
+                defaultValue={values?.description}
+                required
+              />
+            </Field>
           </div>
           <DialogFooter>
             <DialogClose render={<Button type="button" variant="outline" />}>
@@ -205,7 +178,7 @@ const EditItemFormDialog = ({
 
 const EditItemFormDialogTrigger = DialogTrigger;
 
-const items = [
+const lessons = [
   {
     id: "item-1",
     title: "Introduction to React",
@@ -249,126 +222,104 @@ const items = [
   },
 ];
 
-const FormSchema = z.object({
-  items: EditItemFormDialogSchema.array().min(1, {
-    message: "Please add at least 1 item",
-  }),
-});
-
 export default function SortableForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      items,
-    },
-  });
-  const { fields, append, move, remove, update } = useFieldArray({
-    control: form.control,
-    name: "items",
-    keyName: "_id",
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
+  const [items, setItems] = React.useState(lessons);
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-      <Controller
-        control={form.control}
-        name="items"
-        render={({ fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <Sortable
-              modifiers={[restrictToVerticalAxis, restrictToParentElement]}
-              onDragEnd={(event) => {
-                const { active, over } = event;
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Course curriculum</CardTitle>
+        <CardDescription>
+          Drag and drop to reorder the lessons in your course.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Sortable
+          modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+          onDragEnd={(event) => {
+            const { active, over } = event;
 
-                if (over && active.id !== over.id) {
-                  const oldIndex = fields.findIndex(
-                    (field) => field._id === active.id,
-                  );
-                  const newIndex = fields.findIndex(
-                    (field) => field._id === over.id,
-                  );
+            if (over && active.id !== over.id) {
+              setItems((items) => {
+                const oldIndex = items.findIndex(
+                  (item) => item.id === active.id,
+                );
+                const newIndex = items.findIndex((item) => item.id === over.id);
 
-                  move(oldIndex, newIndex);
-                }
-              }}
-            >
-              <SortableList
-                items={fields.map((field) => field._id)}
-                className="flex flex-col gap-3"
-              >
-                {fields.length > 0 ? (
-                  fields.map((field, index) => (
-                    <SortableItem
-                      key={field._id}
-                      id={field._id}
-                      render={
-                        <Item
-                          title={field.title}
-                          description={field.description}
-                          tabIndex={undefined}
-                          onRemove={() => remove(index)}
-                          onEdit={(data) => update(index, data)}
-                          className="aria-pressed:opacity-50 aria-pressed:shadow-sm"
-                        />
-                      }
-                    />
-                  ))
-                ) : (
-                  <div className="text-muted-foreground flex h-32 min-w-96 flex-col items-center justify-center gap-3 rounded-lg border border-dashed text-sm">
-                    No items added
-                  </div>
-                )}
-              </SortableList>
-              <SortableOverlay>
-                {(activeId) => {
-                  const activeItem = fields.find(
-                    (field) => field._id === activeId,
-                  );
-                  if (!activeItem) {
-                    return null;
-                  }
-
-                  return (
+                return arrayMove(items, oldIndex, newIndex);
+              });
+            }
+          }}
+        >
+          <SortableList
+            items={items.map((item) => item.id)}
+            className="flex flex-col gap-3"
+          >
+            {items.length > 0 ? (
+              items.map((item) => (
+                <SortableItem
+                  key={item.id}
+                  id={item.id}
+                  render={
                     <Item
-                      title={activeItem.title}
-                      description={activeItem.description}
-                      onEdit={() => {}}
-                      className="cursor-grabbing shadow-lg"
+                      title={item.title}
+                      description={item.description}
+                      tabIndex={undefined}
+                      onRemove={() =>
+                        setItems((items) =>
+                          items.filter(({ id }) => id !== item.id),
+                        )
+                      }
+                      onEdit={(data) =>
+                        setItems((items) =>
+                          items.map((current) =>
+                            current.id === item.id
+                              ? { ...current, ...data }
+                              : current,
+                          ),
+                        )
+                      }
+                      className="aria-pressed:opacity-50 aria-pressed:shadow-sm"
                     />
-                  );
-                }}
-              </SortableOverlay>
-            </Sortable>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <div className="flex items-center justify-between gap-4">
+                  }
+                />
+              ))
+            ) : (
+              <div className="text-muted-foreground flex h-32 flex-col items-center justify-center gap-3 rounded-lg border border-dashed text-sm">
+                No items added
+              </div>
+            )}
+          </SortableList>
+          <SortableOverlay>
+            {(activeId) => {
+              const activeItem = items.find((item) => item.id === activeId);
+              if (!activeItem) {
+                return null;
+              }
+
+              return (
+                <Item
+                  title={activeItem.title}
+                  description={activeItem.description}
+                  onEdit={() => {}}
+                  className="cursor-grabbing shadow-lg"
+                />
+              );
+            }}
+          </SortableOverlay>
+        </Sortable>
+      </CardContent>
+      <CardFooter className="justify-between gap-4">
         <EditItemFormDialog
           title="Add item"
           description="Add a new item to your list. Click add item when you're done."
           actionText="Add item"
-          onSubmit={(data) => append(data)}
+          onSubmit={(data) =>
+            setItems((items) => [
+              ...items,
+              { id: crypto.randomUUID(), ...data },
+            ])
+          }
         >
           <EditItemFormDialogTrigger
             render={<Button type="button" variant="outline" />}
@@ -377,8 +328,8 @@ export default function SortableForm() {
             Add Item
           </EditItemFormDialogTrigger>
         </EditItemFormDialog>
-        <Button type="submit">Submit</Button>
-      </div>
-    </form>
+        <Button type="submit">Save</Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/time-field-form.tsx
+++ b/apps/v4/src/components/examples/time-field-form.tsx
@@ -1,18 +1,13 @@
-"use client";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   TimeField,
   TimeFieldAmPm,
@@ -22,65 +17,36 @@ import {
   TimeFieldSeparator,
 } from "@/registry/new-york/ui/time-field";
 
-const FormSchema = z.object({
-  eventTime: z.date({
-    required_error: "Event time is required.",
-  }),
-});
-
 export default function TimeFieldForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-  });
-
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
-
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="eventTime"
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel>Event time</FieldLabel>
-            <TimeField
-              hour12
-              value={field.value ?? null}
-              onValueChange={field.onChange}
-            >
-              <TimeFieldHours aria-invalid={fieldState.invalid} />
-              <TimeFieldSeparator />
-              <TimeFieldMinutes />
-              <TimeFieldSeparator />
-              <TimeFieldSeconds />
-              <TimeFieldAmPm />
-            </TimeField>
-            <FieldDescription>
-              Schedule your event by selecting a time.
-            </FieldDescription>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Schedule your event</CardTitle>
+        <CardDescription>
+          Let attendees know when your event takes place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Event time</FieldLabel>
+          <TimeField hour12>
+            <TimeFieldHours />
+            <TimeFieldSeparator />
+            <TimeFieldMinutes />
+            <TimeFieldSeparator />
+            <TimeFieldSeconds />
+            <TimeFieldAmPm />
+          </TimeField>
+          <FieldDescription>
+            Schedule your event by selecting a time.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/components/examples/wheel-picker-form.tsx
+++ b/apps/v4/src/components/examples/wheel-picker-form.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
 import { getHours, getMinutes, setHours, setMinutes } from "date-fns";
 import { ClockIcon } from "lucide-react";
 import * as React from "react";
-import { Controller, useForm } from "react-hook-form";
-import { codeToHtml } from "shiki";
-import { toast } from "sonner";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
-} from "@/components/ui/field";
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { InputGroupButton } from "@/components/ui/input-group";
 import {
   Popover,
@@ -51,117 +49,91 @@ const periods: WheelPickerOption[] = [
   { value: "PM", label: "PM" },
 ];
 
-const FormSchema = z.object({
-  eventTime: z.date({
-    required_error: "Event time is required.",
-  }),
-});
-
 export default function WheelPickerForm() {
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      eventTime: new Date(),
-    },
-  });
+  const [eventTime, setEventTime] = React.useState<Date | null>(new Date());
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const html = await codeToHtml(JSON.stringify(data, null, 2), {
-      lang: "json",
-      theme: "github-dark-dimmed",
-      colorReplacements: {
-        "#22272e": "var(--color-zinc-900)",
-      },
-    });
-
-    toast("You submitted the following values:", {
-      classNames: { content: "w-full" },
-      description: (
-        <div
-          className="mt-2 [&>pre]:rounded-md [&>pre]:p-4 [&>pre]:shadow-[0_1.5px_2px_0_theme(colors.black/32%),0_0_0_1px_theme(colors.white/10%),0_-1px_0_0_theme(colors.white/4%)]"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ),
-    });
-  }
+  const hour = eventTime ? getHours(eventTime) : 0;
+  const minute = eventTime ? getMinutes(eventTime) : 0;
+  const period = hour >= 12 ? "PM" : "AM";
+  const hour12 = hour % 12 || 12;
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-      <Controller
-        control={form.control}
-        name="eventTime"
-        render={({ field, fieldState }) => {
-          const hour = getHours(field.value);
-          const minute = getMinutes(field.value);
-          const period = hour >= 12 ? "PM" : "AM";
-          const hour12 = hour % 12 || 12;
-
-          return (
-            <Field data-invalid={fieldState.invalid}>
-              <FieldLabel>Event time</FieldLabel>
-              <Popover>
-                <TimeField
-                  hour12
-                  value={field.value}
-                  onValueChange={field.onChange}
-                >
-                  <TimeFieldHours aria-invalid={fieldState.invalid} />
-                  <TimeFieldSeparator />
-                  <TimeFieldMinutes />
-                  <TimeFieldSeparator />
-                  <TimeFieldSeconds />
-                  <TimeFieldAmPm />
-                  <PopoverTrigger
-                    className="ml-auto"
-                    render={<InputGroupButton size="icon-xs" />}
-                  >
-                    <ClockIcon />
-                  </PopoverTrigger>
-                </TimeField>
-                <PopoverContent
-                  align="end"
-                  sideOffset={8}
-                  className="border-none p-0 shadow-none"
-                >
-                  <WheelPickerWrapper>
-                    <WheelPicker
-                      infinite
-                      options={hours.slice(1, 13)}
-                      value={hour12.toString()}
-                      onValueChange={(value) => {
-                        const newHour =
-                          parseInt(value) + (period === "PM" ? 12 : 0);
-                        field.onChange(setHours(field.value, newHour));
-                      }}
-                    />
-                    <WheelPicker
-                      infinite
-                      options={minutes}
-                      value={minute.toString()}
-                      onValueChange={(value) =>
-                        field.onChange(setMinutes(field.value, parseInt(value)))
-                      }
-                    />
-                    <WheelPicker
-                      options={periods}
-                      value={period}
-                      onValueChange={(value) => {
-                        const newHour = (hour % 12) + (value === "PM" ? 12 : 0);
-                        field.onChange(setHours(field.value, newHour));
-                      }}
-                    />
-                  </WheelPickerWrapper>
-                </PopoverContent>
-              </Popover>
-              <FieldDescription>
-                Schedule your event by selecting a time.
-              </FieldDescription>
-              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-            </Field>
-          );
-        }}
-      />
-      <Button type="submit">Submit</Button>
-    </form>
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Schedule your event</CardTitle>
+        <CardDescription>
+          Let attendees know when your event takes place.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field>
+          <FieldLabel>Event time</FieldLabel>
+          <Popover>
+            <TimeField hour12 value={eventTime} onValueChange={setEventTime}>
+              <TimeFieldHours />
+              <TimeFieldSeparator />
+              <TimeFieldMinutes />
+              <TimeFieldSeparator />
+              <TimeFieldSeconds />
+              <TimeFieldAmPm />
+              <PopoverTrigger
+                className="ml-auto"
+                render={<InputGroupButton size="icon-xs" />}
+              >
+                <ClockIcon />
+              </PopoverTrigger>
+            </TimeField>
+            <PopoverContent
+              align="end"
+              sideOffset={8}
+              className="border-none p-0 shadow-none"
+            >
+              <WheelPickerWrapper>
+                <WheelPicker
+                  infinite
+                  options={hours.slice(1, 13)}
+                  value={hour12.toString()}
+                  onValueChange={(value) => {
+                    const newHour =
+                      parseInt(value) + (period === "PM" ? 12 : 0);
+                    setEventTime((eventTime) =>
+                      setHours(eventTime ?? new Date(), newHour),
+                    );
+                  }}
+                />
+                <WheelPicker
+                  infinite
+                  options={minutes}
+                  value={minute.toString()}
+                  onValueChange={(value) =>
+                    setEventTime((eventTime) =>
+                      setMinutes(eventTime ?? new Date(), parseInt(value)),
+                    )
+                  }
+                />
+                <WheelPicker
+                  options={periods}
+                  value={period}
+                  onValueChange={(value) => {
+                    const newHour = (hour % 12) + (value === "PM" ? 12 : 0);
+                    setEventTime((eventTime) =>
+                      setHours(eventTime ?? new Date(), newHour),
+                    );
+                  }}
+                />
+              </WheelPickerWrapper>
+            </PopoverContent>
+          </Popover>
+          <FieldDescription>
+            Schedule your event by selecting a time.
+          </FieldDescription>
+        </Field>
+      </CardContent>
+      <CardFooter>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/v4/src/lib/page-tree.ts
+++ b/apps/v4/src/lib/page-tree.ts
@@ -1,30 +1,6 @@
 import type * as PageTree from "fumadocs-core/page-tree";
 import type * as React from "react";
 
-/**
- * Flattens a page tree folder into its pages, including the folder's index
- * page and pages nested in sub-folders, deduplicated by URL.
- */
-export function getPagesFromFolder(folder: PageTree.Folder): PageTree.Item[] {
-  const pages: PageTree.Item[] = [];
-
-  if (folder.index) {
-    pages.push(folder.index);
-  }
-
-  for (const child of folder.children) {
-    if (child.type === "page") {
-      pages.push(child);
-    } else if (child.type === "folder") {
-      pages.push(...getPagesFromFolder(child));
-    }
-  }
-
-  return pages.filter(
-    (page, index, all) => all.findIndex((p) => p.url === page.url) === index,
-  );
-}
-
 export interface FolderSection {
   name?: React.ReactNode;
   pages: PageTree.Item[];

--- a/apps/v4/src/registry/new-york/ui/sortable.tsx
+++ b/apps/v4/src/registry/new-york/ui/sortable.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import type {
-  DndContextProps,
-  UniqueIdentifier,
-} from "@dnd-kit/core";
+import type { DndContextProps, UniqueIdentifier } from "@dnd-kit/core";
 import {
   DndContext,
   DragOverlay,
@@ -58,6 +55,7 @@ export interface SortableProps extends DndContextProps {
 }
 
 function Sortable({
+  id,
   onDragStart,
   onDragEnd,
   onDragCancel,
@@ -66,6 +64,7 @@ function Sortable({
   getTransformStyle = CSS.Transform.toString,
   ...props
 }: SortableProps) {
+  const instanceId = React.useId();
   const [activeId, setActiveId] = React.useState<UniqueIdentifier | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -83,6 +82,7 @@ function Sortable({
       }}
     >
       <DndContext
+        id={id ?? instanceId}
         data-slot="sortable"
         onDragStart={(event) => {
           onDragStart?.(event);


### PR DESCRIPTION
## Summary

Follows shadcn/ui's forms decoupling: component docs no longer ship react-hook-form-wired examples. Instead, each `Form` section is a presentational showcase built with `Field` markup, and form library integration guidance lives centrally at [shadcn/ui docs/forms](https://ui.shadcn.com/docs/forms) — the components work the same with react-hook-form, TanStack Form, or any other form library.

## Changes

- Rewrite all 12 `*-form.tsx` examples as Card-framed scenarios (`Card` + `Field`/`FieldLabel`/`FieldDescription` + submit button), dropping react-hook-form, zod, and submit wiring. Stateless demos lose `"use client"` entirely; interactive ones (badge-group, dropzone, emoji-picker, sortable, wheel-picker) keep minimal `useState`.
- Convert `sortable-form` to `useState` + `arrayMove` with a native `FormData` dialog. Items now own their ids, so the `useFieldArray` `keyName` workaround is gone.
- Remove the now-moot `useFieldArray` callout from `sortable.mdx` and the `parsePhoneNumber` form note from `phone-input.mdx`.
- Fix the `DndDescribedBy` hydration mismatch on the sortable docs page: `<Sortable />` now defaults the `DndContext` id to `React.useId()` instead of dnd-kit's global auto-increment counter, which diverges between server and client renders.
- Pair `{n}` line highlights with `showLineNumbers` in the bprogress and confirmer snippets. The code block styles remove horizontal `pre` padding for highlighted blocks and rely on the line number gutter for the inset — shadcn/ui always pairs the two.
- Add `public/llms.txt` following shadcn/ui's approach: a static llms.txt-spec index of every docs page with its frontmatter description.

## Notes

- `react-hook-form`, `@hookform/resolvers`, and `zod` remain in `apps/v4` deps: the homepage hero (`card-demo-form.tsx`) still legitimately demonstrates real form library integration.

## Verification

- `prettier`, `tsc --noEmit`, and `eslint` all clean
- Browser console spot-checked on all affected docs pages — no errors or warnings, including the previously warning sortable page
- `/llms.txt` serves correctly on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)