### PR TITLE
chore: lint cleanup and pnpm 10 migration

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm commitlint \${1}
+pnpm commitlint "$1"

--- a/apps/v4/eslint.config.mjs
+++ b/apps/v4/eslint.config.mjs
@@ -31,6 +31,15 @@ export default defineConfig([
           ignoreDeclarationSort: true,
         },
       ],
+      // The registry deliberately exports named props interfaces
+      // (`interface XProps extends useRender.ComponentProps<"div"> {}`),
+      // mirroring Base UI's public API idiom.
+      "@typescript-eslint/no-empty-object-type": [
+        "error",
+        {
+          allowInterfaces: "with-single-extends",
+        },
+      ],
       // TODO: New react-hooks v6 rules flag long-standing patterns in the
       // registry components (composed event handlers reading refs, media
       // query hooks). Revisit when refreshing the registry components.

--- a/apps/v4/src/components/ui/calendar.tsx
+++ b/apps/v4/src/components/ui/calendar.tsx
@@ -7,10 +7,10 @@ import {
 } from "lucide-react";
 import * as React from "react";
 import {
-  DayPicker,
-  getDefaultClassNames,
   type DayButton,
+  DayPicker,
   type Locale,
+  getDefaultClassNames,
 } from "react-day-picker";
 
 import { Button, buttonVariants } from "@/components/ui/button";

--- a/apps/v4/src/components/ui/field.tsx
+++ b/apps/v4/src/components/ui/field.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { type VariantProps, cva } from "class-variance-authority";
 import { useMemo } from "react";
-import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
 
 function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (

--- a/apps/v4/src/mdx-components.tsx
+++ b/apps/v4/src/mdx-components.tsx
@@ -20,8 +20,8 @@ import {
 } from "@/components/ui/accordion";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Kbd } from "@/components/ui/kbd";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 function getNodeText(node: React.ReactNode): string {

--- a/apps/v4/src/registry/new-york/ui/date-picker.tsx
+++ b/apps/v4/src/registry/new-york/ui/date-picker.tsx
@@ -4,13 +4,13 @@ import { CalendarIcon, XIcon } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
 } from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
-import { Calendar } from "@/components/ui/calendar";
 import {
   DateFieldDays,
   DateFieldMonths,

--- a/apps/v4/src/registry/new-york/ui/sortable.tsx
+++ b/apps/v4/src/registry/new-york/ui/sortable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
 import type { DndContextProps, UniqueIdentifier } from "@dnd-kit/core";
 import {
   DndContext,
@@ -20,8 +22,6 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS, Transform } from "@dnd-kit/utilities";
-import { mergeProps } from "@base-ui/react/merge-props";
-import { useRender } from "@base-ui/react/use-render";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky"
   },
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@10.34.5",
   "engines": {
     "node": ">=22.11.0"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+# pnpm 10 blocks dependency build scripts unless allowlisted.
+# contentlayer2 and protobufjs are needed by the frozen v3 app only.
+onlyBuiltDependencies:
+  - contentlayer2
+  - esbuild
+  - protobufjs
+  - sharp
+  - unrs-resolver


### PR DESCRIPTION
## Summary

Follow-up to #66, clearing the two items it flagged: the pre-existing lint errors on `next`, and the pnpm 10 migration. One commit each.

### Lint cleanup (`chore(lint)`)

- Auto-fixed the 8 `import/order` / `sort-imports` errors (calendar, field, mdx-components, date-picker, sortable).
- Configured `@typescript-eslint/no-empty-object-type` with `allowInterfaces: "with-single-extends"` instead of rewriting the 7 flagged declarations: six are exported public props interfaces in `timeline.tsx` (`interface TimelineItemProps extends useRender.ComponentProps<"li"> {}` etc.) — a deliberate named-API idiom mirroring Base UI — and converting them to type aliases would churn the public API for no consumer benefit.
- `pnpm lint` is now error-free. The 7 react-hooks v6 warnings (refs-in-render, setState-in-effect) stay downgraded to `warn` with the existing TODO — they're long-standing patterns in vendored shadcn hooks and Base UI's `useControlled`, to revisit during the registry refresh.

### pnpm 10 migration (`chore(pnpm)`)

- `packageManager` → `pnpm@10.34.5`. Corepack picks it up transparently (verified locally — the shim auto-downloads 10.34.5 on first use).
- pnpm 10 keeps the v9 lockfile format: all three lockfiles (root, v3, v4) are **unchanged**.
- The one behavioral change is dependency build scripts being blocked by default. Allowlisted via `onlyBuiltDependencies` in `pnpm-workspace.yaml` (workspace-level, covers all projects): `esbuild`, `sharp`, `unrs-resolver` (v4) plus `contentlayer2`, `protobufjs` (frozen v3).
- **Latent hook bug surfaced**: `.husky/commit-msg` contained `pnpm commitlint \${1}` — the backslash meant `$1` was never expanded. pnpm 9's argument quoting collapsed it to an empty arg, so commitlint silently fell back to `.git/COMMIT_EDITMSG` and the hook appeared to work; pnpm 10 quotes the literal `${1}` through and errors. Fixed to `pnpm commitlint "$1"`.

### Not included

- pnpm 11 is out (`latest` is 11.13.1) — left for its own pass once it's had time to settle.

## Test plan

- `pnpm lint`: 0 errors, 7 warnings (the deliberate react-hooks downgrades)
- `tsc --noEmit` clean
- From-scratch install with pnpm 10.34.5 (`node_modules` removed in all three projects): all allowlisted build scripts run, `pnpm ignored-builds` reports none in root/v3/v4
- Full turbo build (v3 + v4) succeeds under pnpm 10
- commit-msg hook verified live: the migration commit itself ran `commitlint --edit .git/COMMIT_EDITMSG` through the fixed hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
