### PR TITLE
chore(deps): upgrade virtua, timescape, frimousse and use-local-storage-state

### DIFF
--- a/apps/v4/package.json
+++ b/apps/v4/package.json
@@ -28,7 +28,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
     "embla-carousel-react": "8.6.0",
-    "frimousse": "^0.2.0",
+    "frimousse": "^0.3.0",
     "fumadocs-core": "16.10.5",
     "fumadocs-mdx": "15.0.12",
     "lru-cache": "^11.2.4",
@@ -48,9 +48,9 @@
     "shiki": "^4.3.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "timescape": "^0.7.1",
-    "use-local-storage-state": "^19.5.0",
-    "virtua": "^0.41.2",
+    "timescape": "^0.8.0",
+    "use-local-storage-state": "^20.0.0",
+    "virtua": "^0.49.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/v4/pnpm-lock.yaml
+++ b/apps/v4/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: 8.6.0
         version: 8.6.0(react@19.2.7)
       frimousse:
-        specifier: ^0.2.0
-        version: 0.2.0(react@19.2.7)
+        specifier: ^0.3.0
+        version: 0.3.0(react@19.2.7)(typescript@5.9.3)
       fumadocs-core:
         specifier: 16.10.5
         version: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.511.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)
@@ -119,14 +119,14 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       timescape:
-        specifier: ^0.7.1
-        version: 0.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.8.0
+        version: 0.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       use-local-storage-state:
-        specifier: ^19.5.0
-        version: 19.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^20.0.0
+        version: 20.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       virtua:
-        specifier: ^0.41.2
-        version: 0.41.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.49.3
+        version: 0.49.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -993,6 +993,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-arm@1.2.4":
     resolution:
@@ -1001,6 +1002,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-ppc64@1.2.4":
     resolution:
@@ -1009,6 +1011,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-riscv64@1.2.4":
     resolution:
@@ -1017,6 +1020,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-s390x@1.2.4":
     resolution:
@@ -1025,6 +1029,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-x64@1.2.4":
     resolution:
@@ -1033,6 +1038,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
     resolution:
@@ -1041,6 +1047,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-libvips-linuxmusl-x64@1.2.4":
     resolution:
@@ -1049,6 +1056,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-linux-arm64@0.34.5":
     resolution:
@@ -1058,6 +1066,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-arm@0.34.5":
     resolution:
@@ -1067,6 +1076,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-ppc64@0.34.5":
     resolution:
@@ -1076,6 +1086,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-riscv64@0.34.5":
     resolution:
@@ -1085,6 +1096,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-s390x@0.34.5":
     resolution:
@@ -1094,6 +1106,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-x64@0.34.5":
     resolution:
@@ -1103,6 +1116,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linuxmusl-arm64@0.34.5":
     resolution:
@@ -1112,6 +1126,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-linuxmusl-x64@0.34.5":
     resolution:
@@ -1121,6 +1136,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-wasm32@0.34.5":
     resolution:
@@ -1288,6 +1304,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@next/swc-linux-arm64-musl@16.2.10":
     resolution:
@@ -1297,6 +1314,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@next/swc-linux-x64-gnu@16.2.10":
     resolution:
@@ -1306,6 +1324,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@next/swc-linux-x64-musl@16.2.10":
     resolution:
@@ -1315,6 +1334,7 @@ packages:
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@next/swc-win32-arm64-msvc@16.2.10":
     resolution:
@@ -1796,6 +1816,7 @@ packages:
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@tailwindcss/oxide-linux-arm64-musl@4.3.3":
     resolution:
@@ -1805,6 +1826,7 @@ packages:
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@tailwindcss/oxide-linux-x64-gnu@4.3.3":
     resolution:
@@ -1814,6 +1836,7 @@ packages:
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@tailwindcss/oxide-linux-x64-musl@4.3.3":
     resolution:
@@ -1823,6 +1846,7 @@ packages:
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@tailwindcss/oxide-wasm32-wasi@4.3.3":
     resolution:
@@ -2144,6 +2168,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@unrs/resolver-binding-linux-arm64-musl@1.12.2":
     resolution:
@@ -2152,6 +2177,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@unrs/resolver-binding-linux-loong64-gnu@1.12.2":
     resolution:
@@ -2160,6 +2186,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   "@unrs/resolver-binding-linux-loong64-musl@1.12.2":
     resolution:
@@ -2168,6 +2195,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   "@unrs/resolver-binding-linux-ppc64-gnu@1.12.2":
     resolution:
@@ -2176,6 +2204,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@unrs/resolver-binding-linux-riscv64-gnu@1.12.2":
     resolution:
@@ -2184,6 +2213,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@unrs/resolver-binding-linux-riscv64-musl@1.12.2":
     resolution:
@@ -2192,6 +2222,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   "@unrs/resolver-binding-linux-s390x-gnu@1.12.2":
     resolution:
@@ -2200,6 +2231,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@unrs/resolver-binding-linux-x64-gnu@1.12.2":
     resolution:
@@ -2208,6 +2240,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@unrs/resolver-binding-linux-x64-musl@1.12.2":
     resolution:
@@ -2216,6 +2249,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@unrs/resolver-binding-openharmony-arm64@1.12.2":
     resolution:
@@ -3715,13 +3749,17 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  frimousse@0.2.0:
+  frimousse@0.3.0:
     resolution:
       {
-        integrity: sha512-viSrsVQWKR4Q7xzC0lkx3Wu9i1+IHrth0QXn0nlIIJXpltwUnjkGXSTuoW7WHI5aJ4z49WR8E/pyQizFjlNtTA==,
+        integrity: sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ==,
       }
     peerDependencies:
       react: ^18 || ^19
+      typescript: ">=5.1.0"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   fs-extra@11.3.6:
     resolution:
@@ -4778,6 +4816,7 @@ packages:
     engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution:
@@ -4787,6 +4826,7 @@ packages:
     engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution:
@@ -4796,6 +4836,7 @@ packages:
     engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution:
@@ -4805,6 +4846,7 @@ packages:
     engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution:
@@ -6658,10 +6700,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  timescape@0.7.1:
+  timescape@0.8.0:
     resolution:
       {
-        integrity: sha512-v80kXaQ7a1QpgZoR1Sh81qmkGweR4gS80VZiOpRc0sYROOUbT2DDdd5PxynJs2v8NXtgyPCXQNjigf6je5hqgQ==,
+        integrity: sha512-nNYAnZY1BPHSfnnpx3V9wWdxb9z4tB7zksRx0/mRFpZ8gK3fqEMZQ43hHqUDgJICVTb33hmfkeAYaKGkN7Q3Nw==,
       }
     peerDependencies:
       "@preact/signals": 1.x
@@ -6980,10 +7022,10 @@ packages:
       "@types/react":
         optional: true
 
-  use-local-storage-state@19.5.0:
+  use-local-storage-state@20.0.0:
     resolution:
       {
-        integrity: sha512-sUJAyFvsmqMpBhdwaRr7GTKkkoxb6PWeNVvpBDrLuwQF1PpbJRKIbOYeLLeqJI7B3wdfFlLLCBbmOdopiSTBOw==,
+        integrity: sha512-PSaIAivHEv1+XtOr7FwyCYRx5fVf+3uW0d2rr/pbc7zWarHu7U4JQZs5KPaHxAaUVTwPYVJyL0ysdChVV0GR2Q==,
       }
     engines: { node: ">=14" }
     peerDependencies:
@@ -7049,10 +7091,10 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  virtua@0.41.2:
+  virtua@0.49.3:
     resolution:
       {
-        integrity: sha512-48jgdeXKagXEVxalTFf1bJe/5JZq41QG9LcwDweFJwOZgOvIgoHhBR+IMZPOVd0AjtwvLOaS3O7MYNdti9c4VQ==,
+        integrity: sha512-k1Yn988Vz/L40uDtEWPjfdVo15Suumh4tU4/z5Srs0elNcU9DgBskqdh3llpHyAlXrCeHWTfcclYvY1uU4MmIg==,
       }
     peerDependencies:
       react: ">=16.14.0"
@@ -9508,9 +9550,11 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  frimousse@0.2.0(react@19.2.7):
+  frimousse@0.3.0(react@19.2.7)(typescript@5.9.3):
     dependencies:
       react: 19.2.7
+    optionalDependencies:
+      typescript: 5.9.3
 
   fs-extra@11.3.6:
     dependencies:
@@ -11576,7 +11620,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  timescape@0.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  timescape@0.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -11802,7 +11846,7 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.17
 
-  use-local-storage-state@19.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  use-local-storage-state@20.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -11840,7 +11884,7 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  virtua@0.41.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  virtua@0.49.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)

--- a/apps/v4/src/components/examples/virtualizer-select.tsx
+++ b/apps/v4/src/components/examples/virtualizer-select.tsx
@@ -67,7 +67,6 @@ export default function VirtualizerSelect() {
         <VirtualizedVirtualizer
           ref={virtualizerRef}
           keepMounted={activeIndex !== -1 ? [activeIndex] : undefined}
-          overscan={2}
         >
           {items.map((item) => (
             <SelectItem key={item.value} value={item.value}>

--- a/apps/v4/src/components/examples/virtualizer-table.tsx
+++ b/apps/v4/src/components/examples/virtualizer-table.tsx
@@ -21,6 +21,9 @@ import {
   VirtualizedVirtualizer,
 } from "@/registry/new-york/ui/virtualized";
 
+// Seed faker so the server and client generate identical data during hydration.
+faker.seed(42);
+
 const invoices = Array.from({ length: 1000 }, (_, index) => ({
   invoice: `INV${index.toString().padStart(3, "0")}`,
   paymentStatus: faker.helpers.arrayElement(["Unpaid", "Paid", "Overdue"]),

--- a/apps/v4/src/registry/new-york/ui/date-time-field-primitive.tsx
+++ b/apps/v4/src/registry/new-york/ui/date-time-field-primitive.tsx
@@ -15,6 +15,12 @@ export type DateTimeFieldContextProps = {
 const DateTimeFieldContext = React.createContext<DateTimeFieldContextProps>({
   getInputProps: () => ({ ref: () => null }),
   getRootProps: () => ({ ref: () => null }),
+  ampm: {
+    value: undefined,
+    set: () => {},
+    toggle: () => {},
+    getSelectProps: () => ({ value: undefined, onChange: () => {} }),
+  },
   options: {},
   disabled: false,
 });


### PR DESCRIPTION
## Summary

Registry dependency pass: upgrades the four packages that were behind and safe to move, with breaking changes audited against actual usage.

| Package | From | To | Notes |
| --- | --- | --- | --- |
| virtua | 0.42 | 0.49.3 | 0.45–0.48 breaking changes audited (see below) |
| timescape | 0.7 | 0.8.0 | new required `ampm` API on the hook return |
| use-local-storage-state | 19 | 20.0.0 | breaking `isPersistent` semantics — unused here |
| frimousse | 0.2 | 0.3.0 | additive (`sticky` prop) |

## Breaking-change audit

- **virtua 0.45–0.48**: removed `count`, `overscan`, `reverse`, and the `findStartIndex`/`findEndIndex` handle methods, and refactored `experimental_VGrid`. The `virtualized` wrapper uses none of the removed APIs. The one usage of `overscan={2}` (virtualizer select example) was dropped per upstream guidance — its replacement `bufferSize` is pixel-based and the default is recommended; scroll/focus recovery in that demo is handled by `keepMounted`.
- **timescape 0.8**: `useTimescape` now returns a required `ampm` object. Added a matching stub to the `DateTimeField` fallback context; the real hook return already satisfies the type.
- **use-local-storage-state 20**: only breaking change is `isPersistent` semantics; our sole usage (`use-config.ts`) doesn't touch it.

## Verification

- `tsc` clean, production build succeeds.
- Browser-verified against the production build:
  - Virtualizer: select demo with 10k items (windowed rendering, deep-scroll re-render, scroll + focus recovery via `keepMounted` on reopen), `VGrid` 2D scrolling on the refactored `experimental_VGrid`.
  - Date/time fields: segment typing, auto-advance, arrow increment, 12-hour am/pm segment and `a`/`p` toggle, range field.
  - Emoji picker: renders, search filters with category grouping, behavior identical to the deployed site.
  - Package-manager tab choice persists across reload (use-local-storage-state).
## Bonus fix

The virtualizer docs page had a pre-existing React hydration mismatch (#418, reproducible on the deployed site): the table example generated invoice data at module scope with unseeded faker, so server and client rendered different rows and footer totals. Seeding faker makes the data deterministic; the page's console is now clean in both dev and production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
