### PR TITLE
docs: add API reference and accessibility sections

### DIFF
--- a/apps/v4/content/docs/components/badge-group.mdx
+++ b/apps/v4/content/docs/components/badge-group.mdx
@@ -71,3 +71,31 @@ import { BadgeGroup, BadgeGroupItem } from "@/components/ui/badge-group";
 ### Form
 
 <ComponentPreview name="badge-group-form" />
+
+## Accessibility
+
+The group is built on [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group): one item is tabbable at a time, the arrow keys move focus between items, and <Kbd>Space</Kbd> or <Kbd>Enter</Kbd> toggles the focused item. When removal is enabled, <Kbd>Backspace</Kbd> and <Kbd>Delete</Kbd> remove the focused item — the close icon is a pointer-only affordance hidden from assistive technology, so keyboard and screen-reader users are not dependent on it.
+
+## API Reference
+
+### BadgeGroup
+
+The group container. Renders a [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group).
+
+| Prop            | Type                     | Default    | Description                                                                                                                                    |
+| --------------- | ------------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`          | `"single" \| "multiple"` | `"single"` | Whether one or several items can be pressed at a time. Determines the value type below.                                                        |
+| `value`         | `string \| string[]`     | -          | The pressed item(s), typed by `type`. Use for controlled value.                                                                                |
+| `defaultValue`  | `string \| string[]`     | -          | The initial value when uncontrolled.                                                                                                           |
+| `onValueChange` | `(value) => void`        | -          | Called when the pressed item(s) change. The value is typed by `type`.                                                                          |
+| `onRemove`      | `(value) => void`        | -          | Enables removal. Called with the removed value(s) when an item's close icon is clicked or <Kbd>Backspace</Kbd> / <Kbd>Delete</Kbd> is pressed. |
+| `...props`      | `ToggleGroup.Props`      | -          | Remaining props are spread to [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group#api-reference).                         |
+
+### BadgeGroupItem
+
+A single badge. Renders a [Base UI Toggle](https://base-ui.com/react/components/toggle) styled as an outline [Badge](https://ui.shadcn.com/docs/components/badge). Shows a close icon when the group has `onRemove`.
+
+| Prop       | Type           | Default | Description                                                                                                |
+| ---------- | -------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `value`    | `string`       | -       | The item's value within the group. Required.                                                               |
+| `...props` | `Toggle.Props` | -       | Remaining props are spread to [Base UI Toggle](https://base-ui.com/react/components/toggle#api-reference). |

--- a/apps/v4/content/docs/components/bprogress/next.mdx
+++ b/apps/v4/content/docs/components/bprogress/next.mdx
@@ -162,3 +162,17 @@ export default function App({ Component, pageProps }: AppProps) {
 </TabsContent>
 
 </Tabs>
+
+## API Reference
+
+### BProgressProvider
+
+Wraps `@bprogress/next`'s progress provider (`AppProgressProvider` for the App Router, `PagesProgressProvider` for the Pages Router) with theme-aware defaults, and accepts all of its props — see the [BProgress provider documentation](https://bprogress.vercel.app/docs/next/app-dir/provider) for the full list.
+
+| Prop             | Type                    | Default                         | Description                                                         |
+| ---------------- | ----------------------- | ------------------------------- | ------------------------------------------------------------------- |
+| `color`          | `string`                | `"var(--primary)"`              | The progress bar color.                                             |
+| `height`         | `string`                | `"calc(var(--spacing) * 0.75)"` | The progress bar height.                                            |
+| `options`        | `ProgressOptions`       | `{ showSpinner: false }`        | [BProgress options](https://bprogress.vercel.app/docs/api#options). |
+| `shallowRouting` | `boolean`               | `true`                          | Skips the progress bar when only search params change.              |
+| `...props`       | `ProgressProviderProps` | -                               | Props spread to the underlying provider.                            |

--- a/apps/v4/content/docs/components/confirmer.mdx
+++ b/apps/v4/content/docs/components/confirmer.mdx
@@ -126,3 +126,26 @@ confirm({
 ### Default
 
 <ComponentPreview name="confirmer-demo" />
+
+## API Reference
+
+### Confirmer
+
+The dialog host. Render it once near the root of your app; it renders nothing until `confirm` is called. Takes no props.
+
+### confirm
+
+Opens the confirm dialog imperatively and resolves with the user's choice — `true` for the action button, `false` for cancel or dismissing the dialog.
+
+```tsx
+function confirm(options?: ConfirmOptions): Promise<boolean>;
+```
+
+| Option        | Type                                             | Default           | Description                                                                                         |
+| ------------- | ------------------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------- |
+| `title`       | `ReactNode`                                      | `"Are you sure?"` | The dialog title.                                                                                   |
+| `description` | `ReactNode`                                      | -                 | The dialog description.                                                                             |
+| `cancelText`  | `ReactNode`                                      | `"Cancel"`        | The cancel button label.                                                                            |
+| `actionText`  | `ReactNode`                                      | `"Continue"`      | The action button label.                                                                            |
+| `CancelProps` | `React.ComponentProps<typeof AlertDialogCancel>` | -                 | Props spread to the cancel button.                                                                  |
+| `ActionProps` | `React.ComponentProps<typeof AlertDialogAction>` | -                 | Props spread to the action button, e.g. `{ variant: "destructive" }` for destructive confirmations. |

--- a/apps/v4/content/docs/components/date-field.mdx
+++ b/apps/v4/content/docs/components/date-field.mdx
@@ -81,3 +81,23 @@ import {
 ### Form
 
 <ComponentPreview name="date-field-form" />
+
+## Accessibility
+
+The field follows the segment keyboard model and labeling guidance described in the [Date Time Field accessibility](/docs/components/date-time-field#accessibility) section.
+
+## API Reference
+
+A date-only preset of the [Date Time Field](/docs/components/date-time-field#api-reference) — each part wraps its Date Time Field counterpart and accepts the same props.
+
+### DateField
+
+Wraps `DateTimeField` and accepts all of the [Root props](/docs/primitives/date-time-field#root) (`value`, `onValueChange`, `minDate`, `maxDate`, …).
+
+### DateFieldDays, DateFieldMonths, DateFieldYears
+
+Wrap the corresponding [segments](/docs/primitives/date-time-field#segments) with their default placeholders (`dd`, `mm`, `yyyy`).
+
+### DateFieldSeparator
+
+Wraps the [separator](/docs/components/date-time-field#datetimefieldseparator) with `/` as the default children.

--- a/apps/v4/content/docs/components/date-picker.mdx
+++ b/apps/v4/content/docs/components/date-picker.mdx
@@ -63,3 +63,53 @@ See installation instructions for the [Button](https://ui.shadcn.com/docs/compon
 ### Form
 
 <ComponentPreview name="date-picker-form" />
+
+## Accessibility
+
+### Labeling
+
+The trigger and clear buttons in the input variant are icon-only. `<DatePickerInput />` ships a visually hidden "Clear date" label for the clear button; when composing your own icon-only triggers, give them an accessible name with `aria-label` or a visually hidden `<span className="sr-only">`.
+
+### Keyboard interactions
+
+The inline date field follows the segment keyboard model described in the [Date Time Field accessibility](/docs/components/date-time-field#accessibility) section. Inside the popover, the calendar supports the arrow keys to move between days, <Kbd>PageUp</Kbd> / <Kbd>PageDown</Kbd> to change months and <Kbd>Enter</Kbd> to select. <Kbd>Escape</Kbd> closes the popover and returns focus to the trigger.
+
+## API Reference
+
+Styled wrappers around the [Date Picker primitive](/docs/primitives/date-picker#api-reference). Each part forwards its props to the primitive part it wraps — see the primitive page for the full prop tables.
+
+### DatePicker
+
+Wraps [Root](/docs/primitives/date-picker#root) and accepts all of its props (`mode`, `value`, `onValueChange`, `formatStr`, `month`, `required`, `disabled`, …).
+
+### DatePickerTrigger
+
+Wraps [Trigger](/docs/primitives/date-picker#trigger), rendered as an outline `<Button />` with a calendar icon.
+
+### DatePickerValue
+
+Wraps [Value](/docs/primitives/date-picker#value), muting the placeholder text. Accepts `placeholder`.
+
+### DatePickerInput
+
+An [Input Group](https://ui.shadcn.com/docs/components/input-group) containing the inline date field plus clear and open buttons. Renders a single-date field or a range field automatically based on the root's `mode`; the inline field is not supported in `"multiple"` mode. Accepts the corresponding [DateField / DateRangeField props](/docs/primitives/date-picker#datefield).
+
+### DatePickerAnchor
+
+Wraps [Anchor](/docs/primitives/date-picker#anchor) for positioning the popover against a custom element.
+
+### DatePickerContent
+
+Wraps [Portal, Positioner and Content](/docs/primitives/date-picker#portal-positioner-content) with popover styling, and lifts the common positioning props.
+
+| Prop          | Type                                     | Default    | Description                                 |
+| ------------- | ---------------------------------------- | ---------- | ------------------------------------------- |
+| `align`       | `"start" \| "center" \| "end"`           | `"start"`  | Alignment against the anchor.               |
+| `alignOffset` | `number`                                 | `4`        | Offset along the alignment axis.            |
+| `side`        | `"top" \| "bottom" \| "left" \| "right"` | `"bottom"` | Side of the anchor to render against.       |
+| `sideOffset`  | `number`                                 | `0`        | Distance from the anchor.                   |
+| `...props`    | `Content props`                          | -          | Remaining props spread to the content part. |
+
+### DatePickerCalendar
+
+Wraps [Calendar](/docs/primitives/date-picker#calendar), rendering the styled [Calendar](https://ui.shadcn.com/docs/components/calendar) component. Accepts the styled calendar's props.

--- a/apps/v4/content/docs/components/date-time-field.mdx
+++ b/apps/v4/content/docs/components/date-time-field.mdx
@@ -92,3 +92,39 @@ import {
 ### Form
 
 <ComponentPreview name="date-time-field-form" />
+
+## Accessibility
+
+### Labeling
+
+Each segment is an individual `<input>`, so the field needs a group label: associate a visible label with the field (for example via `<Field>` and `<FieldLabel>` in forms), or label the group with `aria-labelledby`. Separators are decorative and hidden from assistive technology with `aria-hidden`.
+
+### Keyboard interactions
+
+| Key                                        | Description                                                          |
+| ------------------------------------------ | -------------------------------------------------------------------- |
+| <Kbd>ArrowLeft</Kbd> <Kbd>ArrowRight</Kbd> | Moves focus to the previous / next segment.                          |
+| <Kbd>ArrowUp</Kbd> <Kbd>ArrowDown</Kbd>    | Increments / decrements the focused segment.                         |
+| <Kbd>0</Kbd>–<Kbd>9</Kbd>                  | Types a value into the segment, advancing to the next when complete. |
+| <Kbd>A</Kbd> <Kbd>P</Kbd>                  | Sets the meridiem segment to AM / PM.                                |
+| <Kbd>Backspace</Kbd> <Kbd>Delete</Kbd>     | Clears the focused segment.                                          |
+
+## API Reference
+
+Styled wrappers around the [Date Time Field primitive](/docs/primitives/date-time-field#api-reference) — see the primitive page for the full prop tables.
+
+### DateTimeField
+
+Wraps [Root](/docs/primitives/date-time-field#root) and accepts all of its props (`value`, `onValueChange`, `hour12`, `minDate`, `maxDate`, …), rendered as an [Input Group](https://ui.shadcn.com/docs/components/input-group).
+
+### DateTimeFieldDays, DateTimeFieldMonths, DateTimeFieldYears, DateTimeFieldHours, DateTimeFieldMinutes, DateTimeFieldSeconds
+
+Wrap the corresponding [segments](/docs/primitives/date-time-field#segments) with input styling and default placeholders (`dd`, `mm`, `yyyy` and `--` for the time segments).
+
+### DateTimeFieldAmPm
+
+Wraps [AmPm](/docs/primitives/date-time-field#ampm); renders only when the field has `hour12`.
+
+### DateTimeFieldSeparator
+
+Wraps [Separator](/docs/primitives/date-time-field#separator) with muted styling. Pass the separator character as `children` (e.g. `/` or `:`).

--- a/apps/v4/content/docs/components/date-time-range-field.mdx
+++ b/apps/v4/content/docs/components/date-time-range-field.mdx
@@ -113,3 +113,31 @@ import {
 ### Form
 
 <ComponentPreview name="date-time-range-field-form" />
+
+## Accessibility
+
+The field follows the segment keyboard model and labeling guidance described in the [Date Time Field accessibility](/docs/components/date-time-field#accessibility) section. Since the range spans two groups of segments, prefer one visible label for the whole field, or label the `From` and `To` groups individually with `aria-label` when they need distinct names.
+
+## API Reference
+
+Styled wrappers around the [Date Time Range Field primitive](/docs/primitives/date-time-range-field#api-reference) — see the primitive page for the full prop tables.
+
+### DateTimeRangeField
+
+Wraps [Root](/docs/primitives/date-time-range-field#root) and accepts all of its props (`value`, `onValueChange`, `hour12`, `from`, `to`, …), rendered as an [Input Group](https://ui.shadcn.com/docs/components/input-group).
+
+### DateTimeRangeFieldFrom, DateTimeRangeFieldTo
+
+Wrap [From and To](/docs/primitives/date-time-range-field#from-to). Segments must be placed inside one of the two.
+
+### DateTimeRangeFieldDays, DateTimeRangeFieldMonths, DateTimeRangeFieldYears, DateTimeRangeFieldHours, DateTimeRangeFieldMinutes, DateTimeRangeFieldSeconds
+
+Wrap the corresponding [segments](/docs/primitives/date-time-range-field#segments), rendered with the [Date Time Field](/docs/components/date-time-field#api-reference) segment styling and placeholders.
+
+### DateTimeRangeFieldAmPm
+
+Wraps [AmPm](/docs/primitives/date-time-range-field#ampm); renders only when its field has `hour12`.
+
+### DateTimeRangeFieldSeparator
+
+Wraps the styled [Date Time Field separator](/docs/components/date-time-field#datetimefieldseparator). Pass the separator character as `children` (e.g. `/`, `:` or `-` between the two fields).

--- a/apps/v4/content/docs/components/description-list.mdx
+++ b/apps/v4/content/docs/components/description-list.mdx
@@ -81,3 +81,39 @@ import {
   </DescriptionGroup>
 </DescriptionList>
 ```
+
+## API Reference
+
+All parts render semantic HTML description-list elements and accept the corresponding element props.
+
+### DescriptionList
+
+The list container. Renders a `<dl>`.
+
+| Prop       | Type                         | Default | Description                         |
+| ---------- | ---------------------------- | ------- | ----------------------------------- |
+| `...props` | `React.ComponentProps<"dl">` | -       | Props spread to the `<dl>` element. |
+
+### DescriptionGroup
+
+Groups a term with its details for layout. Renders a `<div>`.
+
+| Prop       | Type                          | Default | Description                          |
+| ---------- | ----------------------------- | ------- | ------------------------------------ |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the `<div>` element. |
+
+### DescriptionTerm
+
+The term being described. Renders a `<dt>`.
+
+| Prop       | Type                         | Default | Description                         |
+| ---------- | ---------------------------- | ------- | ----------------------------------- |
+| `...props` | `React.ComponentProps<"dt">` | -       | Props spread to the `<dt>` element. |
+
+### DescriptionDetail
+
+The description of the preceding term. Renders a `<dd>`.
+
+| Prop       | Type                         | Default | Description                         |
+| ---------- | ---------------------------- | ------- | ----------------------------------- |
+| `...props` | `React.ComponentProps<"dd">` | -       | Props spread to the `<dd>` element. |

--- a/apps/v4/content/docs/components/dropzone.mdx
+++ b/apps/v4/content/docs/components/dropzone.mdx
@@ -110,3 +110,39 @@ import {
 ### Form
 
 <ComponentPreview name="dropzone-form" />
+
+## Accessibility
+
+The zone is focusable and opens the file dialog with <Kbd>Enter</Kbd> or <Kbd>Space</Kbd>, so the drag-and-drop interaction always has a keyboard equivalent. Make sure the zone contains visible text describing what to upload (such as `<DropzoneTitle />` and `<DropzoneDescription />`) — the upload icon alone is not an accessible name. Drag states are conveyed with color and iconography via `<DropzoneUploadIcon />`; keep the title text meaningful so the state change is not communicated by color alone.
+
+## API Reference
+
+Styled wrappers around the [Dropzone primitive](/docs/primitives/dropzone#api-reference) — see the primitive page for the full prop tables.
+
+### Dropzone
+
+Wraps [Root](/docs/primitives/dropzone#root) and accepts all [react-dropzone options](https://react-dropzone.js.org/#src) (`accept`, `maxFiles`, `onDropAccepted`, …).
+
+### DropzoneZone
+
+Wraps [Zone](/docs/primitives/dropzone#zone) with dashed-border styling that reacts to the drag state data attributes.
+
+### DropzoneInput
+
+Wraps [Input](/docs/primitives/dropzone#input), the visually hidden file input.
+
+### DropzoneTrigger
+
+Wraps [Trigger](/docs/primitives/dropzone#trigger) for opening the file dialog from a button outside the zone.
+
+### DropzoneUploadIcon
+
+A convenience part that renders an upload, accepted or rejected icon based on the current drag state, using the [DragDefault](/docs/primitives/dropzone#dragdefault), [DragAccepted](/docs/primitives/dropzone#dragaccepted) and [DragRejected](/docs/primitives/dropzone#dragrejected) parts. Accepts `lucide-react` icon props.
+
+### DropzoneGroup, DropzoneTitle, DropzoneDescription
+
+Layout and typography parts for the zone's content. Render a `<div>`, `<h3>` and `<p>` respectively, and support the `render` prop.
+
+### DropzoneAccepted, DropzoneRejected
+
+Wrap [Accepted and Rejected](/docs/primitives/dropzone#accepted), render-prop parts receiving the accepted files or rejections.

--- a/apps/v4/content/docs/components/emoji-picker.mdx
+++ b/apps/v4/content/docs/components/emoji-picker.mdx
@@ -83,3 +83,23 @@ import {
 **Tip**: If you're looking to build a robust input field that supports emoji insertion, you're likely looking for a rich text editor. Some interesting solutions worth exploring include [Novel](https://novel.sh/) (powered by [Tiptap](https://tiptap.dev/)), [Plate](https://platejs.org/) (powered by [Slate](https://slatejs.org)), or [shadcn-editor](https://shadcn-editor.vercel.app/) (powered by [Lexical](https://lexical.dev/)). For lower-level control, you can also look into their underlying frameworks.
 
 </Callout>
+
+## API Reference
+
+Styled wrappers around [frimousse](https://frimousse.liveblocks.io/) — see the [frimousse API reference](https://frimousse.liveblocks.io/#api-reference) for the underlying props.
+
+### EmojiPicker
+
+Wraps `EmojiPicker.Root` and accepts all of its props (`onEmojiSelect`, `locale`, `skinTone`, `columns`, …).
+
+### EmojiPickerSearch
+
+Wraps `EmojiPicker.Search` with a search icon, accepting standard `<input>` props such as `placeholder`.
+
+### EmojiPickerContent
+
+Wraps `EmojiPicker.Viewport` with the loading, empty and list states already composed and styled.
+
+### EmojiPickerFooter
+
+A footer showing a preview of the active emoji and a skin tone selector. Renders a `<div>` and accepts its props.

--- a/apps/v4/content/docs/components/password-input.mdx
+++ b/apps/v4/content/docs/components/password-input.mdx
@@ -79,3 +79,27 @@ import {
 ### Form
 
 <ComponentPreview name="password-input-form" />
+
+## Accessibility
+
+The visibility toggle is icon-only — give it an accessible name, e.g. `<PasswordInputAdornmentToggle aria-label="Show password" />`. The eye icons are decorative and hidden from assistive technology. The input renders as `type="password"` until toggled, so browser and password-manager behavior is unaffected by the extra parts.
+
+## API Reference
+
+Styled wrappers around the [Password Input primitive](/docs/primitives/password-input#api-reference) — see the primitive page for the full prop tables.
+
+### PasswordInput
+
+Wraps [Root](/docs/primitives/password-input#root) (`visible`, `defaultVisible`, `onVisibleChange`), rendered as an [Input Group](https://ui.shadcn.com/docs/components/input-group); remaining props go to the group element.
+
+### PasswordInputInput
+
+Wraps [Input](/docs/primitives/password-input#input) with input-group styling. Accepts standard `<input>` props such as `placeholder` and `autoComplete`.
+
+### PasswordInputAdornmentToggle
+
+Wraps [Toggle](/docs/primitives/password-input#toggle) as an icon button in the trailing addon, swapping the eye icon based on the visibility state.
+
+### PasswordInputAdornment, PasswordInputAdornmentButton
+
+Input-group addon and icon-button parts for composing custom adornments, e.g. a leading lock icon or a custom toggle.

--- a/apps/v4/content/docs/components/phone-input.mdx
+++ b/apps/v4/content/docs/components/phone-input.mdx
@@ -92,3 +92,35 @@ import { PhoneInput } from "@/components/ui/phone-input";
 ### Form
 
 <ComponentPreview name="phone-input-form" />
+
+## Accessibility
+
+The country select trigger shows only a flag — give it an accessible name, e.g. `<PhoneInputCountrySelectTrigger aria-label="Country" />`, and label the phone input itself like any text input (via `<Field>` / `<FieldLabel>` in forms or `aria-label`). Flags are decorative; each option in the dropdown carries the country's name as text, so the selection is not communicated by the flag alone.
+
+## API Reference
+
+Styled wrappers around the [Phone Input primitive](/docs/primitives/phone-input#api-reference) — see the primitive page for the full prop tables.
+
+### PhoneInput
+
+Wraps [Root](/docs/primitives/phone-input#root) and accepts all of its props (`value`, `onValueChange`, `country`, `onCountryChange`, `preferredCountry`, `international`, …).
+
+### PhoneInputInput
+
+Wraps [Input](/docs/primitives/phone-input#input), rendered as the styled [Input](https://ui.shadcn.com/docs/components/input) with a stable `render` reference already applied.
+
+### PhoneInputCountrySelect
+
+The country selector, built on the styled [Select](https://ui.shadcn.com/docs/components/select) and wired to the country state — `value` and `onValueChange` are managed for you. Compose it with `PhoneInputCountrySelectTrigger`, `PhoneInputCountrySelectValue` and `PhoneInputCountrySelectContent`, which accept the corresponding Select part props.
+
+### PhoneInputCountrySelectOptions
+
+Renders the full options list: the "International" item followed by every supported country with its flag, name and calling code.
+
+### PhoneInputCountrySelectItem, PhoneInputCountrySelectInternationalItem
+
+Individual option items for composing a custom list. `PhoneInputCountrySelectItem` requires a `value: Country`; the international item selects `null`.
+
+### PhoneInputFlag
+
+Renders the flag for a `country`, falling back to a globe icon for `null` (International).

--- a/apps/v4/content/docs/components/time-field.mdx
+++ b/apps/v4/content/docs/components/time-field.mdx
@@ -87,3 +87,27 @@ import {
 ### Form
 
 <ComponentPreview name="time-field-form" />
+
+## Accessibility
+
+The field follows the segment keyboard model and labeling guidance described in the [Date Time Field accessibility](/docs/components/date-time-field#accessibility) section, including <Kbd>A</Kbd> / <Kbd>P</Kbd> for the meridiem segment.
+
+## API Reference
+
+A time-only preset of the [Date Time Field](/docs/components/date-time-field#api-reference) — each part wraps its Date Time Field counterpart and accepts the same props.
+
+### TimeField
+
+Wraps `DateTimeField` and accepts all of the [Root props](/docs/primitives/date-time-field#root) (`value`, `onValueChange`, `hour12`, …).
+
+### TimeFieldHours, TimeFieldMinutes, TimeFieldSeconds
+
+Wrap the corresponding [segments](/docs/primitives/date-time-field#segments) with `--` as the default placeholder.
+
+### TimeFieldAmPm
+
+Wraps [AmPm](/docs/primitives/date-time-field#ampm); renders only when the field has `hour12`.
+
+### TimeFieldSeparator
+
+Wraps the [separator](/docs/components/date-time-field#datetimefieldseparator) with `:` as the default children.

--- a/apps/v4/content/docs/components/time.mdx
+++ b/apps/v4/content/docs/components/time.mdx
@@ -62,3 +62,16 @@ import { Time } from "@/components/ui/time";
 ### Format
 
 <ComponentPreview name="time-format" />
+
+## API Reference
+
+### Time
+
+Renders a semantic `<time>` element with a machine-readable `dateTime` attribute, formatting both with [date-fns format](https://date-fns.org/docs/format).
+
+| Prop                | Type                           | Default        | Description                                       |
+| ------------------- | ------------------------------ | -------------- | ------------------------------------------------- |
+| `children`          | `Date \| string \| number`     | -              | The date to display. Required.                    |
+| `formatStr`         | `string`                       | `"PPP"`        | The date-fns format for the visible text.         |
+| `dateTimeFormatStr` | `string`                       | `"yyyy-MM-dd"` | The date-fns format for the `dateTime` attribute. |
+| `...props`          | `React.ComponentProps<"time">` | -              | Props spread to the `<time>` element.             |

--- a/apps/v4/content/docs/components/timeline.mdx
+++ b/apps/v4/content/docs/components/timeline.mdx
@@ -123,6 +123,66 @@ import {
 
 <ComponentPreview name="timeline-horizontal" />
 
+## Accessibility
+
+The timeline renders an ordered list (`<ol role="list">`), so assistive technology announces the number of events and their order. Dots and connectors are purely visual — keep the meaning of each event in its `TimelineTitle` and `TimelineDescription` text rather than in the dot's color or icon alone.
+
+## API Reference
+
+### Timeline
+
+The list container. Renders an `<ol>`.
+
+| Prop          | Type                         | Default      | Description                           |
+| ------------- | ---------------------------- | ------------ | ------------------------------------- |
+| `orientation` | `"horizontal" \| "vertical"` | `"vertical"` | The layout direction of the timeline. |
+| `...props`    | `React.ComponentProps<"ol">` | -            | Props spread to the list element.     |
+
+### TimelineItem
+
+A single event. Renders an `<li>`.
+
+| Prop       | Type                         | Default | Description                       |
+| ---------- | ---------------------------- | ------- | --------------------------------- |
+| `render`   | `ReactElement \| function`   | -       | Render as a different element.    |
+| `...props` | `React.ComponentProps<"li">` | -       | Props spread to the item element. |
+
+### TimelineSeparator
+
+Lays out the dot and connector alongside the content. Renders a `<div>`.
+
+| Prop       | Type                          | Default | Description                            |
+| ---------- | ----------------------------- | ------- | -------------------------------------- |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.         |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the separator element. |
+
+### TimelineDot
+
+The event marker. Renders a `<div>` showing a dot while empty; place an icon inside to replace it.
+
+| Prop       | Type                          | Default     | Description                                 |
+| ---------- | ----------------------------- | ----------- | ------------------------------------------- |
+| `variant`  | `"default" \| "outline"`      | `"default"` | Filled or outlined dot when rendered empty. |
+| `render`   | `ReactElement \| function`    | -           | Render as a different element.              |
+| `...props` | `React.ComponentProps<"div">` | -           | Props spread to the dot element.            |
+
+### TimelineConnector
+
+The line connecting one event to the next. Renders a `<div>`; omit it on the last item.
+
+| Prop       | Type                          | Default | Description                            |
+| ---------- | ----------------------------- | ------- | -------------------------------------- |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.         |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the connector element. |
+
+### TimelineContent, TimelineTitle, TimelineDescription
+
+The event's content, heading text and supporting text. Each renders a `<div>` and supports the `render` prop.
+
+### useTimeline
+
+Hook exposing the timeline context (`orientation`) for building custom parts. Must be used within `<Timeline />`.
+
 ## Changelog
 
 ### 10 Febuary 2025 - a11y for title and description

--- a/apps/v4/content/docs/components/wheel-picker.mdx
+++ b/apps/v4/content/docs/components/wheel-picker.mdx
@@ -65,3 +65,15 @@ import { WheelPicker, WheelPickerWrapper } from "@/components/ui/wheel-picker";
 ### Form
 
 <ComponentPreview name="wheel-picker-form" />
+
+## API Reference
+
+Styled wrappers around [react-wheel-picker](https://react-wheel-picker.chanhdai.com/) — see its [API reference](https://react-wheel-picker.chanhdai.com/docs#api-reference) for the underlying props.
+
+### WheelPickerWrapper
+
+Wraps `WheelPickerWrapper` with border and highlight styling. Place one or more `<WheelPicker />` columns inside.
+
+### WheelPicker
+
+Wraps `WheelPicker` with themed option and highlight classes, and accepts all of its props (`options`, `value`, `onValueChange`, `infinite`, `visibleCount`, …). The exported `WheelPickerOption` type describes the `options` items.

--- a/apps/v4/content/docs/primitives/date-picker.mdx
+++ b/apps/v4/content/docs/primitives/date-picker.mdx
@@ -57,7 +57,13 @@ export default () => (
     <DatePickerPrimitive.Trigger>
       <DatePickerPrimitive.Value />
     </DatePickerPrimitive.Trigger>
-    <DatePickerPrimitive.Input />
+    <DatePickerPrimitive.DateField>
+      <DatePickerPrimitive.DateFieldDays />
+      <DatePickerPrimitive.DateFieldSeparator />
+      <DatePickerPrimitive.DateFieldMonths />
+      <DatePickerPrimitive.DateFieldSeparator />
+      <DatePickerPrimitive.DateFieldYears />
+    </DatePickerPrimitive.DateField>
     <DatePickerPrimitive.Clear />
     <DatePickerPrimitive.Anchor />
 
@@ -85,3 +91,81 @@ export default () => (
 ### Range
 
 <ComponentPreview name="date-picker-primitive-range" />
+
+## API Reference
+
+### Root
+
+Manages the selected value, the visible month and the popover state. Built on top of [Base UI Popover](https://base-ui.com/react/components/popover).
+
+| Prop            | Type                                  | Default       | Description                                                                                                       |
+| --------------- | ------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `mode`          | `"single" \| "multiple" \| "range"`   | `"single"`    | The selection mode. Determines the value type below.                                                              |
+| `required`      | `boolean`                             | `false`       | Prevents clearing the selection. When set, the value is no longer nullable.                                       |
+| `value`         | `Date \| Date[] \| DateRange \| null` | -             | The selected value, typed by `mode`. Use for controlled value; pass `null` for empty.                             |
+| `defaultValue`  | `Date \| Date[] \| DateRange`         | -             | The initial value when uncontrolled.                                                                              |
+| `onValueChange` | `(value) => void`                     | -             | Called when the selection changes. The value is typed by `mode`.                                                  |
+| `formatStr`     | `string`                              | `"PPP"`       | The [date-fns format](https://date-fns.org/docs/format) used by `Value` to display the selection.                 |
+| `month`         | `Date`                                | -             | The month shown in the calendar. Use for controlled month.                                                        |
+| `defaultMonth`  | `Date`                                | current month | The initial month when uncontrolled.                                                                              |
+| `onMonthChange` | `(month: Date) => void`               | -             | Called when the visible month changes.                                                                            |
+| `disabled`      | `boolean`                             | -             | Disables the trigger, the clear button and the calendar.                                                          |
+| `...props`      | `PopoverPrimitive.Root.Props`         | -             | Remaining props are spread to [Base UI Popover.Root](https://base-ui.com/react/components/popover#api-reference). |
+
+### Trigger
+
+Opens the popover. See the [Base UI Popover.Trigger](https://base-ui.com/react/components/popover#api-reference) documentation for more information.
+
+### Value
+
+Displays the current selection formatted with `formatStr`, joining multiple dates with `", "` and ranges as `from - to`. Has a `data-placeholder` attribute while empty. Renders a `<span>` by default.
+
+| Prop          | Type                           | Default | Description                        |
+| ------------- | ------------------------------ | ------- | ---------------------------------- |
+| `placeholder` | `ReactNode`                    | -       | Content shown while empty.         |
+| `render`      | `ReactElement \| function`     | -       | Render as a different element.     |
+| `...props`    | `React.ComponentProps<"span">` | -       | Props spread to the value element. |
+
+### Clear
+
+Clears the selection. Disabled while the value is empty or the root is `required`. Renders a `<button type="button">` by default.
+
+| Prop       | Type                             | Default | Description                        |
+| ---------- | -------------------------------- | ------- | ---------------------------------- |
+| `render`   | `ReactElement \| function`       | -       | Render as a different element.     |
+| `...props` | `React.ComponentProps<"button">` | -       | Props spread to the clear element. |
+
+### DateField
+
+An inline [Date Time Field](/docs/primitives/date-time-field) synced with the picker — typing a date updates the selection and the visible month. Only usable when `mode` is `"single"`. Accepts the [Date Time Field Root props](/docs/primitives/date-time-field#root) except `value` and `onValueChange`, which are managed by the picker. Compose it with the `DateFieldDays`, `DateFieldMonths`, `DateFieldYears` and `DateFieldSeparator` [segments](/docs/primitives/date-time-field#segments).
+
+### DateRangeField
+
+An inline [Date Time Range Field](/docs/primitives/date-time-range-field) synced with the picker. Only usable when `mode` is `"range"`. Accepts the [Date Time Range Field Root props](/docs/primitives/date-time-range-field#root) except `value` and `onValueChange`. Compose it with `DateRangeFieldFrom` and `DateRangeFieldTo` containers wrapping the `DateRangeFieldDays`, `DateRangeFieldMonths`, `DateRangeFieldYears` and `DateRangeFieldSeparator` [segments](/docs/primitives/date-time-range-field#segments).
+
+### Anchor
+
+An optional element the popover positions against instead of the trigger. Renders a `<div>` by default.
+
+| Prop       | Type                          | Default | Description                         |
+| ---------- | ----------------------------- | ------- | ----------------------------------- |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.      |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the anchor element. |
+
+### Portal, Positioner, Content
+
+Thin wrappers around the corresponding [Base UI Popover](https://base-ui.com/react/components/popover#api-reference) parts (`Portal`, `Positioner` and `Popup`). `Positioner` anchors to the `Anchor` element when one is rendered. See the Base UI documentation for more information.
+
+### Calendar
+
+The calendar inside the popover, rendered with [react-day-picker](https://daypicker.dev). Selection, month and disabled state are wired to the root.
+
+| Prop        | Type             | Default | Description                                                                                                                                                     |
+| ----------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoFocus` | `boolean`        | `true`  | Focuses the calendar when the popover opens.                                                                                                                    |
+| `render`    | `ReactElement`   | -       | Render a custom `DayPicker` element, e.g. a styled calendar component.                                                                                          |
+| `...props`  | `DayPickerProps` | -       | Remaining [react-day-picker props](https://daypicker.dev/api/type-aliases/DayPickerProps) are spread, except the selection and month props managed by the root. |
+
+### useDatePicker
+
+Hook exposing the date picker context (`mode`, `value`, `onValueChange`, `month`, `onMonthChange`, `formatStr`, `required`, `disabled`, `anchor`, `onAnchorChange`) for building custom parts. Must be used within `<DatePickerPrimitive.Root>`.

--- a/apps/v4/content/docs/primitives/date-time-field.mdx
+++ b/apps/v4/content/docs/primitives/date-time-field.mdx
@@ -93,3 +93,54 @@ export default () => (
 ### Disabled
 
 <ComponentPreview name="date-time-field-primitive-disabled" />
+
+## API Reference
+
+### Root
+
+Runs [timescape](https://github.com/dan-lee/timescape) and provides its state to the segments. Renders a `<div>` by default that manages focus between segments.
+
+| Prop            | Type                            | Default     | Description                                                                |
+| --------------- | ------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| `value`         | `Date \| null`                  | -           | The date value. Use for controlled value; pass `null` for empty.           |
+| `defaultValue`  | `Date`                          | -           | The initial value when uncontrolled.                                       |
+| `onValueChange` | `(value: Date \| null) => void` | -           | Called when the value changes.                                             |
+| `digits`        | `"numeric" \| "2-digit"`        | `"2-digit"` | Whether segments are zero-padded.                                          |
+| `hour12`        | `boolean`                       | `false`     | Use a 12-hour clock. Required for the `AmPm` segment to render.            |
+| `minDate`       | `Date`                          | -           | The minimum selectable date.                                               |
+| `maxDate`       | `Date`                          | -           | The maximum selectable date.                                               |
+| `snapToStep`    | `boolean`                       | `false`     | Snap values to the segment's `step` when incrementing.                     |
+| `wheelControl`  | `boolean`                       | `false`     | Allow changing segment values with the mouse wheel.                        |
+| `wrapAround`    | `boolean`                       | `false`     | Wrap from the last value back to the first when incrementing past the end. |
+| `disabled`      | `boolean`                       | -           | Disables every segment.                                                    |
+| `render`        | `ReactElement \| function`      | -           | Render as a different element.                                             |
+| `...props`      | `React.ComponentProps<"div">`   | -           | Props spread to the root element.                                          |
+
+See the [timescape options](https://github.com/dan-lee/timescape?tab=readme-ov-file#options) for more detail on the option props.
+
+### Segments
+
+The `Days`, `Months`, `Years`, `Hours`, `Minutes` and `Seconds` parts. Each renders an `<input>` wired to its timescape segment and shares the same props.
+
+| Prop       | Type                            | Default | Description                          |
+| ---------- | ------------------------------- | ------- | ------------------------------------ |
+| `disabled` | `boolean`                       | -       | Disables this segment only.          |
+| `render`   | `ReactElement \| function`      | -       | Render as a different element.       |
+| `...props` | `React.ComponentProps<"input">` | -       | Props spread to the segment element. |
+
+### AmPm
+
+The meridiem segment. Renders only when the root has `hour12`; toggle it with <Kbd>A</Kbd> / <Kbd>P</Kbd> or the arrow keys. Same props as the other segments.
+
+### Separator
+
+A decorative separator between segments (e.g. `/` or `:`). Hidden from assistive technology with `aria-hidden`. Renders a `<span>` by default.
+
+| Prop       | Type                           | Default | Description                            |
+| ---------- | ------------------------------ | ------- | -------------------------------------- |
+| `render`   | `ReactElement \| function`     | -       | Render as a different element.         |
+| `...props` | `React.ComponentProps<"span">` | -       | Props spread to the separator element. |
+
+### useDateTimeField
+
+Hook exposing the field context (`getInputProps`, `getRootProps`, `options`, `disabled`) for building custom segments. Must be used within `<DateTimeFieldPrimitive.Root>`.

--- a/apps/v4/content/docs/primitives/date-time-range-field.mdx
+++ b/apps/v4/content/docs/primitives/date-time-range-field.mdx
@@ -116,3 +116,65 @@ export default () => (
 ### Disabled
 
 <ComponentPreview name="date-time-range-field-primitive-disabled" />
+
+## API Reference
+
+### Root
+
+Runs [timescape](https://github.com/dan-lee/timescape)'s range mode and provides the `from` and `to` fields to the parts below. Renders a `<div>` by default that manages focus across both fields.
+
+| Prop            | Type                                 | Default     | Description                                                                                      |
+| --------------- | ------------------------------------ | ----------- | ------------------------------------------------------------------------------------------------ |
+| `value`         | `DateRange \| null`                  | -           | The range value (`{ from?: Date; to?: Date }`). Use for controlled value; pass `null` for empty. |
+| `defaultValue`  | `DateRange`                          | -           | The initial value when uncontrolled.                                                             |
+| `onValueChange` | `(value: DateRange \| null) => void` | -           | Called when the range changes.                                                                   |
+| `digits`        | `"numeric" \| "2-digit"`             | `"2-digit"` | Whether segments are zero-padded.                                                                |
+| `hour12`        | `boolean`                            | `false`     | Use a 12-hour clock. Required for the `AmPm` segments to render.                                 |
+| `minDate`       | `Date`                               | -           | The minimum selectable date.                                                                     |
+| `maxDate`       | `Date`                               | -           | The maximum selectable date.                                                                     |
+| `snapToStep`    | `boolean`                            | `false`     | Snap values to the segment's `step` when incrementing.                                           |
+| `wheelControl`  | `boolean`                            | `false`     | Allow changing segment values with the mouse wheel.                                              |
+| `wrapAround`    | `boolean`                            | `false`     | Wrap from the last value back to the first when incrementing past the end.                       |
+| `from`          | `TimescapeOptions`                   | -           | Option overrides applied to the `from` field only.                                               |
+| `to`            | `TimescapeOptions`                   | -           | Option overrides applied to the `to` field only.                                                 |
+| `disabled`      | `boolean`                            | -           | Disables every segment.                                                                          |
+| `render`        | `ReactElement \| function`           | -           | Render as a different element.                                                                   |
+| `...props`      | `React.ComponentProps<"div">`        | -           | Props spread to the root element.                                                                |
+
+See the [timescape options](https://github.com/dan-lee/timescape?tab=readme-ov-file#options) for more detail on the option props.
+
+### From, To
+
+Containers that scope the segments inside them to the start or end of the range. Segments must be placed inside one of the two. Each renders a `<div>` by default.
+
+| Prop       | Type                          | Default | Description                            |
+| ---------- | ----------------------------- | ------- | -------------------------------------- |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.         |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the container element. |
+
+### Segments
+
+The `Days`, `Months`, `Years`, `Hours`, `Minutes` and `Seconds` parts, identical to the [Date Time Field segments](/docs/primitives/date-time-field#segments). Each renders an `<input>` and must live inside `From` or `To`.
+
+| Prop       | Type                            | Default | Description                          |
+| ---------- | ------------------------------- | ------- | ------------------------------------ |
+| `disabled` | `boolean`                       | -       | Disables this segment only.          |
+| `render`   | `ReactElement \| function`      | -       | Render as a different element.       |
+| `...props` | `React.ComponentProps<"input">` | -       | Props spread to the segment element. |
+
+### AmPm
+
+The meridiem segment. Renders only when `hour12` is set for its field. Same props as the other segments.
+
+### Separator
+
+A decorative separator, hidden from assistive technology with `aria-hidden`. Renders a `<span>` by default.
+
+| Prop       | Type                           | Default | Description                            |
+| ---------- | ------------------------------ | ------- | -------------------------------------- |
+| `render`   | `ReactElement \| function`     | -       | Render as a different element.         |
+| `...props` | `React.ComponentProps<"span">` | -       | Props spread to the separator element. |
+
+### useDateTimeRangeField
+
+Hook exposing the range field context (`from`, `to`, `getRootProps`, `disabled`) for building custom parts. Must be used within `<DateTimeRangeFieldPrimitive.Root>`.

--- a/apps/v4/content/docs/primitives/dropzone.mdx
+++ b/apps/v4/content/docs/primitives/dropzone.mdx
@@ -67,3 +67,83 @@ export default () => (
   </DropzonePrimitive.Root>
 );
 ```
+
+## API Reference
+
+### Root
+
+The dropzone provider. Runs [react-dropzone](https://react-dropzone.js.org)'s `useDropzone` and shares its state with the parts below. Renders no element of its own.
+
+| Prop         | Type                                                      | Default | Description                                                                                                                                                                             |
+| ------------ | --------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode \| (state: DropzoneContextProps) => ReactNode` | -       | The dropzone parts, or a render function that receives the full dropzone state and options.                                                                                             |
+| `...options` | `DropzoneOptions`                                         | -       | All [react-dropzone options](https://react-dropzone.js.org/#!/Dropzone) — `accept`, `maxFiles`, `maxSize`, `multiple`, `disabled`, `noClick`, `noKeyboard`, `onDrop`, `validator`, etc. |
+
+### Input
+
+The visually hidden file input. Merges react-dropzone's `getInputProps`. Renders an `<input type="file">` by default.
+
+| Prop       | Type                            | Default | Description                                     |
+| ---------- | ------------------------------- | ------- | ----------------------------------------------- |
+| `render`   | `ReactElement \| function`      | -       | Render as a different element.                  |
+| `...props` | `React.ComponentProps<"input">` | -       | Props merged into react-dropzone's input props. |
+
+### Zone
+
+The droppable area. Merges react-dropzone's `getRootProps`, so by default it is focusable and opens the file dialog on click, <Kbd>Enter</Kbd> or <Kbd>Space</Kbd>. Renders a `<div>` by default.
+
+| Prop       | Type                          | Default | Description                                    |
+| ---------- | ----------------------------- | ------- | ---------------------------------------------- |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.                 |
+| `...props` | `React.ComponentProps<"div">` | -       | Props merged into react-dropzone's root props. |
+
+The zone exposes its state for styling via data attributes: `data-drag-active`, `data-drag-accept`, `data-drag-reject`, `data-focused`, `data-file-dialog-active` and `data-disabled`, plus the option flags `data-no-click`, `data-no-keyboard`, `data-no-drag`, `data-no-drag-events-bubbling` and `data-prevent-drop-on-document`.
+
+### Trigger
+
+A button that opens the file dialog. Useful when the zone itself has `noClick`. Renders a `<button>` by default.
+
+| Prop       | Type                             | Default | Description                          |
+| ---------- | -------------------------------- | ------- | ------------------------------------ |
+| `render`   | `ReactElement \| function`       | -       | Render as a different element.       |
+| `...props` | `React.ComponentProps<"button">` | -       | Props spread to the trigger element. |
+
+### DragAccepted
+
+Renders its children only while a drag over the zone would be accepted.
+
+| Prop       | Type        | Default | Description                                 |
+| ---------- | ----------- | ------- | ------------------------------------------- |
+| `children` | `ReactNode` | -       | Content shown while the drag is acceptable. |
+
+### DragRejected
+
+Renders its children only while a drag over the zone would be rejected.
+
+| Prop       | Type        | Default | Description                               |
+| ---------- | ----------- | ------- | ----------------------------------------- |
+| `children` | `ReactNode` | -       | Content shown while the drag is rejected. |
+
+### DragDefault
+
+Renders its children only while no drag is in progress.
+
+| Prop       | Type        | Default | Description                            |
+| ---------- | ----------- | ------- | -------------------------------------- |
+| `children` | `ReactNode` | -       | Content shown when nothing is dragged. |
+
+### Accepted
+
+Render-prop container for the accepted files.
+
+| Prop       | Type                                                    | Default | Description                                       |
+| ---------- | ------------------------------------------------------- | ------- | ------------------------------------------------- |
+| `children` | `(acceptedFiles: readonly FileWithPath[]) => ReactNode` | -       | Render function that receives the accepted files. |
+
+### Rejected
+
+Render-prop container for the rejected files.
+
+| Prop       | Type                                                      | Default | Description                                        |
+| ---------- | --------------------------------------------------------- | ------- | -------------------------------------------------- |
+| `children` | `(fileRejections: readonly FileRejection[]) => ReactNode` | -       | Render function that receives the file rejections. |

--- a/apps/v4/content/docs/primitives/password-input.mdx
+++ b/apps/v4/content/docs/primitives/password-input.mdx
@@ -67,3 +67,43 @@ export default () => (
 ### Checkbox
 
 <ComponentPreview name="password-input-primitive-checkbox" />
+
+## API Reference
+
+### Root
+
+Manages the visibility state and provides it to the parts below. Renders no element of its own.
+
+| Prop              | Type                         | Default | Description                                                     |
+| ----------------- | ---------------------------- | ------- | --------------------------------------------------------------- |
+| `visible`         | `boolean`                    | -       | Whether the password is visible. Use for controlled visibility. |
+| `defaultVisible`  | `boolean`                    | `false` | The initial visibility when uncontrolled.                       |
+| `onVisibleChange` | `(visible: boolean) => void` | -       | Called when the visibility changes.                             |
+| `children`        | `ReactNode`                  | -       | The password input parts.                                       |
+
+### Input
+
+The password input. Switches its `type` between `password` and `text` based on the visibility. Renders an `<input>` by default.
+
+| Prop       | Type                            | Default | Description                        |
+| ---------- | ------------------------------- | ------- | ---------------------------------- |
+| `render`   | `ReactElement \| function`      | -       | Render as a different element.     |
+| `...props` | `React.ComponentProps<"input">` | -       | Props spread to the input element. |
+
+### Toggle
+
+Toggles the visibility. Renders a `<button type="button">` by default; the render function receives the `{ visible }` state.
+
+| Prop       | Type                             | Default | Description                                                      |
+| ---------- | -------------------------------- | ------- | ---------------------------------------------------------------- |
+| `render`   | `ReactElement \| function`       | -       | Render as a different element. Receives the `{ visible }` state. |
+| `...props` | `React.ComponentProps<"button">` | -       | Props spread to the toggle element.                              |
+
+### Indicator
+
+A presentational slot for visibility-dependent content such as an eye icon. Hidden from assistive technology with `aria-hidden`. Renders a `<span>` by default; the render function receives the `{ visible }` state.
+
+| Prop       | Type                           | Default | Description                                                      |
+| ---------- | ------------------------------ | ------- | ---------------------------------------------------------------- |
+| `render`   | `ReactElement \| function`     | -       | Render as a different element. Receives the `{ visible }` state. |
+| `...props` | `React.ComponentProps<"span">` | -       | Props spread to the indicator element.                           |

--- a/apps/v4/content/docs/primitives/phone-input.mdx
+++ b/apps/v4/content/docs/primitives/phone-input.mdx
@@ -141,3 +141,66 @@ In this example, the default country is set to Malaysia, with the initial value 
 To ensure stable behavior and prevent focus issues, it's recommended to always wrap your `render` element with `useMemo` to maintain a stable reference. Avoid passing inline elements without `useMemo`, as this will cause focus issues on each change.
 
 </Callout>
+
+## API Reference
+
+### Root
+
+Manages the phone value and selected country and provides them to the parts below. Renders no element of its own.
+
+| Prop                                      | Type                                 | Default | Description                                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`                                   | `Value`                              | -       | The phone number in E.164 format (e.g. `"+12133734253"`). Use for controlled value.                                                                                     |
+| `defaultValue`                            | `Value`                              | `""`    | The initial value when uncontrolled.                                                                                                                                    |
+| `onValueChange`                           | `(value: Value) => void`             | -       | Called when the phone number changes.                                                                                                                                   |
+| `country`                                 | `Country \| null`                    | -       | The selected country. `null` means "International". Use for controlled country.                                                                                         |
+| `defaultCountry`                          | `Country`                            | -       | The initial country when uncontrolled.                                                                                                                                  |
+| `onCountryChange`                         | `(country: Country \| null) => void` | -       | Called when the selected country changes.                                                                                                                               |
+| `preferredCountry`                        | `Country`                            | -       | Suggests a country while no country is selected: numbers can be typed in this country's national format while international numbers for any other country keep working. |
+| `defaultInternationalForPreferredCountry` | `boolean`                            | `false` | Forces international format for initial values that match the preferred country. Only valid together with `preferredCountry`.                                           |
+| `international`                           | `boolean`                            | `false` | Forces international format when a country is explicitly selected.                                                                                                      |
+| `withCountryCallingCode`                  | `boolean`                            | `false` | Keeps the country calling code visible and undeletable in international format. Only valid together with `international`.                                               |
+| `disabled`                                | `boolean`                            | `false` | Disables the input and the country select.                                                                                                                              |
+| `children`                                | `ReactNode`                          | -       | The phone input parts.                                                                                                                                                  |
+
+### Input
+
+The phone number input, formatting as you type via [react-phone-number-input](https://catamphetamine.gitlab.io/react-phone-number-input/). Renders an `<input>` by default.
+
+| Prop         | Type                                           | Default | Description                                                                                                             |
+| ------------ | ---------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `render`     | `ReactElement`                                 | -       | Render as a different input element. Wrap it in `useMemo` — see the callout above.                                      |
+| `smartCaret` | `boolean`                                      | `true`  | Keeps the caret position stable while the value is reformatted.                                                         |
+| `...props`   | `React.ComponentProps<typeof ReactPhoneInput>` | -       | Remaining [react-phone-number-input props](https://catamphetamine.gitlab.io/react-phone-number-input/docs/) are spread. |
+
+### CountrySelect
+
+The country selector. Renders a native `<select>` wired to the country state.
+
+| Prop       | Type                             | Default | Description                         |
+| ---------- | -------------------------------- | ------- | ----------------------------------- |
+| `...props` | `React.ComponentProps<"select">` | -       | Props spread to the select element. |
+
+### CountrySelectOption
+
+A country option. Renders an `<option>`.
+
+| Prop       | Type                             | Default | Description                         |
+| ---------- | -------------------------------- | ------- | ----------------------------------- |
+| `...props` | `React.ComponentProps<"option">` | -       | Props spread to the option element. |
+
+### CountryInternationalSelectOption
+
+The "International" option. Selecting it clears the country (`null`).
+
+| Prop       | Type                                            | Default | Description                         |
+| ---------- | ----------------------------------------------- | ------- | ----------------------------------- |
+| `...props` | `Omit<React.ComponentProps<"option">, "value">` | -       | Props spread to the option element. |
+
+### getCountryOptions
+
+A helper that returns `{ countryCode, countryCallingCode }` for every supported country — useful for rendering the options list.
+
+### usePhoneInput
+
+Hook exposing the phone input context (`value`, `country`, change handlers, `disabled`) for building custom parts. Must be used within `<PhoneInput.Root>`.

--- a/apps/v4/content/docs/utilities/sortable.mdx
+++ b/apps/v4/content/docs/utilities/sortable.mdx
@@ -105,3 +105,79 @@ import {
 ### Virtualized
 
 <ComponentPreview name="virtualizer-sortable" />
+
+## Accessibility
+
+Keyboard sorting is preconfigured through @dnd-kit's [KeyboardSensor](https://docs.dndkit.com/api-documentation/sensors/keyboard): focus an item (or its `<SortableItemTrigger />` handle), press <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> to pick it up, move it with the arrow keys, then press <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> again to drop it or <Kbd>Escape</Kbd> to cancel.
+
+Screen reader announcements ("Picked up sortable item…") are provided by @dnd-kit and can be customized via the `accessibility` prop on `<Sortable />` — see the [@dnd-kit accessibility guide](https://docs.dndkit.com/guides/accessibility).
+
+When items are only draggable via a handle, keep the `<SortableItemTrigger />` a real `<button>` (the default) so it is focusable, and give icon-only handles an accessible name, e.g. `aria-label="Reorder"`.
+
+## API Reference
+
+### Sortable
+
+The root context. Wraps @dnd-kit's [DndContext](https://docs.dndkit.com/api-documentation/context-provider) with pointer and keyboard sensors and `closestCenter` collision detection preconfigured. Handle reordering in `onDragEnd`.
+
+| Prop                 | Type                                                    | Default                  | Description                                                                                      |
+| -------------------- | ------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `getNewIndex`        | `NewIndexGetter`                                        | -                        | Computes the index an item moves to when sorting with the keyboard, e.g. for swap-based sorting. |
+| `getTransformStyle`  | `(transform: Transform \| null) => string \| undefined` | `CSS.Transform.toString` | Converts an item's transform into its CSS `transform` style.                                     |
+| `collisionDetection` | `CollisionDetection`                                    | `closestCenter`          | The collision detection algorithm.                                                               |
+| `...props`           | `DndContextProps`                                       | -                        | Props spread to [DndContext](https://docs.dndkit.com/api-documentation/context-provider#props).  |
+
+### SortableList
+
+A sortable list. Wraps @dnd-kit's [SortableContext](https://docs.dndkit.com/presets/sortable/sortable-context) and renders a `<ul>`.
+
+| Prop          | Type                             | Default                    | Description                                                                                                                                |
+| ------------- | -------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `items`       | `(UniqueIdentifier \| { id })[]` | -                          | The sorted item identifiers, in render order.                                                                                              |
+| `orientation` | `"vertical" \| "horizontal"`     | `"vertical"`               | The layout direction of the list.                                                                                                          |
+| `strategy`    | `SortingStrategy`                | Derived from `orientation` | The [sorting strategy](https://docs.dndkit.com/presets/sortable#sorting-strategies); defaults to the vertical or horizontal list strategy. |
+| `disabled`    | `boolean \| Disabled`            | -                          | Disables sorting for the whole list.                                                                                                       |
+| `render`      | `ReactElement \| function`       | -                          | Render as a different element.                                                                                                             |
+| `...props`    | `React.ComponentProps<"ul">`     | -                          | Props spread to the list element.                                                                                                          |
+
+### SortableGrid
+
+A sortable grid. Same as `<SortableList />` but renders a `<div>` and defaults to @dnd-kit's `rectSortingStrategy`, which suits grid layouts.
+
+| Prop       | Type                             | Default               | Description                                   |
+| ---------- | -------------------------------- | --------------------- | --------------------------------------------- |
+| `items`    | `(UniqueIdentifier \| { id })[]` | -                     | The sorted item identifiers, in render order. |
+| `strategy` | `SortingStrategy`                | `rectSortingStrategy` | The sorting strategy.                         |
+| `disabled` | `boolean \| Disabled`            | -                     | Disables sorting for the whole grid.          |
+| `render`   | `ReactElement \| function`       | -                     | Render as a different element.                |
+| `...props` | `React.ComponentProps<"div">`    | -                     | Props spread to the grid element.             |
+
+### SortableItem
+
+A sortable item. Renders a `<div>` that is draggable as a whole unless a `<SortableItemTrigger />` handle is present. Exposes `data-dragging`, `data-over` and `data-sorting` attributes for styling.
+
+| Prop       | Type                          | Default | Description                                                                |
+| ---------- | ----------------------------- | ------- | -------------------------------------------------------------------------- |
+| `id`       | `UniqueIdentifier`            | -       | The item's unique identifier. Must match an entry in the parent's `items`. |
+| `disabled` | `boolean \| Disabled`         | -       | Disables sorting for this item.                                            |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.                                             |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the item element.                                          |
+
+### SortableItemTrigger
+
+A drag handle. Renders a `<button>`; when present, dragging (pointer and keyboard) starts from the handle instead of the whole item. Exposes the same `data-dragging`, `data-over` and `data-sorting` attributes.
+
+| Prop       | Type                             | Default | Description                         |
+| ---------- | -------------------------------- | ------- | ----------------------------------- |
+| `disabled` | `boolean`                        | -       | Disables the handle.                |
+| `render`   | `ReactElement \| function`       | -       | Render as a different element.      |
+| `...props` | `React.ComponentProps<"button">` | -       | Props spread to the handle element. |
+
+### SortableOverlay
+
+The drag preview. Wraps @dnd-kit's [DragOverlay](https://docs.dndkit.com/api-documentation/draggable/drag-overlay) in a portal to `document.body` and renders its children only while an item is being dragged.
+
+| Prop       | Type                                               | Default | Description                                                                                            |
+| ---------- | -------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `children` | `ReactNode \| (id: UniqueIdentifier) => ReactNode` | -       | The preview content; the function form receives the active item's identifier.                          |
+| `...props` | `React.ComponentProps<typeof DragOverlay>`         | -       | Props spread to [DragOverlay](https://docs.dndkit.com/api-documentation/draggable/drag-overlay#props). |

--- a/apps/v4/content/docs/utilities/virtualizer.mdx
+++ b/apps/v4/content/docs/utilities/virtualizer.mdx
@@ -357,3 +357,33 @@ export function VirtualizedSelectDemo() {
 This section is empty for now.
 
 </Callout>
+
+## API Reference
+
+Thin wrappers around [virtua](https://github.com/inokawa/virtua) — see the [virtua API reference](https://github.com/inokawa/virtua/blob/main/docs/react/API.md) for the full list of underlying props and imperative handle methods.
+
+### Virtualized
+
+The scrollable container. Renders a `<div>` and provides its scroll ref to a `<VirtualizedVirtualizer />` inside. Use the `render` prop to attach the scroll container to an existing component, e.g. `render={<ComboboxContent />}`.
+
+| Prop       | Type                          | Default | Description                            |
+| ---------- | ----------------------------- | ------- | -------------------------------------- |
+| `render`   | `ReactElement \| function`    | -       | Render as a different element.         |
+| `...props` | `React.ComponentProps<"div">` | -       | Props spread to the container element. |
+
+### VirtualizedList
+
+A standalone virtualized list that scrolls itself. Wraps virtua's [VList](https://github.com/inokawa/virtua/blob/main/docs/react/API.md#vlist) and accepts all of its props (`keepMounted`, `shift`, imperative `ref`, …). Must not be used within a `<Virtualized />` — use `<VirtualizedVirtualizer />` there instead.
+
+| Prop          | Type                                 | Default      | Description                       |
+| ------------- | ------------------------------------ | ------------ | --------------------------------- |
+| `orientation` | `"vertical" \| "horizontal"`         | `"vertical"` | The scroll direction of the list. |
+| `...props`    | `React.ComponentProps<typeof VList>` | -            | Props spread to virtua's `VList`. |
+
+### VirtualizedGrid
+
+A virtualized grid that virtualizes both rows and columns. Wraps virtua's experimental [VGrid](https://github.com/inokawa/virtua/blob/main/docs/react/API.md#experimental_vgrid) and accepts all of its props (`row`, `col`, `cellHeight`, `cellWidth`, …).
+
+### VirtualizedVirtualizer
+
+The virtualized viewport for a `<Virtualized />` container. Wraps virtua's [Virtualizer](https://github.com/inokawa/virtua/blob/main/docs/react/API.md#virtualizer) with `scrollRef` already wired to the surrounding `<Virtualized />`, and accepts all of its remaining props (`startMargin`, `keepMounted`, imperative `ref`, …).


### PR DESCRIPTION
## Summary

Adds shadcn-style `## API Reference` sections across the docs (25 pages), plus `## Accessibility` sections where there is real guidance — completing the ROADMAP Phase 4d item scheduled after the component ports.

### What's covered

- **Primitives (6)** — dropzone, password-input, phone-input, date-time-field, date-time-range-field, date-picker: full prop tables per part, sourced from the registry code (`Prop | Type | Default | Description`, shadcn conventions for `render` / `...props` rows). Also fixes the stale `<DatePickerPrimitive.Input />` in the date picker primitive's anatomy.
- **Styled components (6)** — defer to their primitive's tables and document only the styled layer (e.g. `DatePickerContent` positioning defaults). Accessibility guidance lives here; the canonical date/time segment keyboard model is on the Date Time Field page, with other pages linking to it.
- **Standalone components (9)** — badge-group, confirmer, date-field, time-field, time, description-list, timeline, emoji-picker, wheel-picker: full tables for ui-x-owned APIs, one-line deferrals for thin wrappers over frimousse / react-wheel-picker.
- **Utilities + BProgress (4)** — sortable (full tables + @dnd-kit keyboard/screen-reader accessibility), virtualizer (virtua link-outs), BProgress provider defaults table.

### Notes

- Cross-page anchors verified against the built output — fumadocs' `remarkHeading` assigns github-slugger ids, so multi-part headings like "From, To" resolve to `#from-to` as linked.
- No timescape 0.8 API mentions — docs match what's on `next` (0.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)