### PR TITLE
fix(date-time-field): tighten segment height to match input-group rhythm

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -200,9 +200,11 @@ demos.
       `Field`/`Form` for form plumbing, replacing `ui/form.tsx`); verify
       every page — shipped 2026-07-16 (PR #63); form demos stay controlled
       from first render (`field.value ?? null`).
-- [ ] Styling polish during the ports: date/time field segments render
-      taller than desired (noted 2026-07-16) — revisit segment height when
-      applying nova classes to the field components.
+- [x] Styling polish during the ports: date/time field segments rendered
+      taller than desired (noted 2026-07-16) — fixed 2026-07-18: segments
+      now use `py-0.5` instead of inheriting the input's `py-1`, so the
+      focus pill is 24px inside the 32px control, matching the height of
+      inline buttons in nova input groups.
 - [x] Update registry.json (single style) and install docs after the
       removals + ports — done 2026-07-16: internal `registryDependencies`
       switched from dead self-hosted `https://ui-x.junwen-k.dev/r/*.json`

--- a/apps/v4/src/registry/new-york/ui/date-time-field.tsx
+++ b/apps/v4/src/registry/new-york/ui/date-time-field.tsx
@@ -33,7 +33,7 @@ function DateTimeFieldSeparator({
 }
 
 const dateTimeFieldInputStyle =
-  "focus:bg-primary dark:focus:bg-primary focus:text-primary-foreground focus:placeholder:text-primary-foreground box-content h-fit flex-initial rounded-sm px-0.5 tabular-nums";
+  "focus:bg-primary dark:focus:bg-primary focus:text-primary-foreground focus:placeholder:text-primary-foreground box-content h-fit flex-initial rounded-sm px-0.5 py-0.5 tabular-nums";
 
 function DateTimeFieldYears({
   placeholder = "yyyy",


### PR DESCRIPTION
## Summary

Closes the last 4c styling-polish item on the roadmap: date/time field segments rendered taller than desired.

Segments inherited the base input's `py-1` on top of their `box-content h-fit` overrides, so the focus pill measured **28px inside the 32px nova control** — visually chunky, nearly touching the border. This changes the shared `dateTimeFieldInputStyle` to `py-0.5`, bringing the pill to **24px**, which matches the height of inline buttons inside nova input groups (verified on the date-picker page: segment 24px, calendar button 24px, group 32px).

One constant covers all consumers: date-time-field, date-field, time-field, date-time-range-field and date-picker.

Also ticks the corresponding ROADMAP.md item.

## Verification

- Measured before/after in-browser (Chrome DevTools): segment 28px → 24px, control stays 32px.
- Checked date-time-field and date-picker pages; focused-segment pill now hugs the text line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)