### PR TITLE
fix(phone-input): let country select popup size to its content

### DIFF
--- a/apps/v4/src/registry/new-york/ui/phone-input.tsx
+++ b/apps/v4/src/registry/new-york/ui/phone-input.tsx
@@ -114,11 +114,16 @@ function PhoneInputCountrySelectTrigger(
   );
 }
 
-function PhoneInputCountrySelectContent(
-  props: React.ComponentProps<typeof SelectContent>,
-) {
+function PhoneInputCountrySelectContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectContent>) {
   return (
-    <SelectContent data-slot="phone-input-country-select-content" {...props} />
+    <SelectContent
+      data-slot="phone-input-country-select-content"
+      className={cn("w-auto", className)}
+      {...props}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

The country select dropdown in the phone input regressed after the Base UI + nova port: country names wrapped across 2–3 lines in a popup clamped to ~144px.

**Root cause:** the vendored nova `SelectContent` popup pins its width to the trigger via `w-(--anchor-width)` with a `min-w-36` floor. That works for normal selects whose trigger is as wide as its content, but the phone input's trigger is a small flag-only button — so the popup collapsed to the minimum. The previous select auto-sized its popup to content, which is why this used to look fine.

**Fix:** `PhoneInputCountrySelectContent` now passes `className={cn("w-auto", className)}` to the wrapped `SelectContent` — tailwind-merge lets `w-auto` win over `w-(--anchor-width)`, so the popup sizes to its content again while `min-w-36` remains as a floor. Consumers can still override via `className`.

## Verification

Checked in the running dev server on the phone-input docs page:
- Popup now measures **334.5px** wide (was ~190px); all 245 country items render single-line at 32px tall — zero wrapped items.
- Verified on both the **Default** and **Separated** examples; dial codes stay right-aligned, selected-item check indicator intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)