### PR TITLE
docs(changelog): announce the Base UI overhaul

### DIFF
--- a/apps/v4/content/docs/changelog.mdx
+++ b/apps/v4/content/docs/changelog.mdx
@@ -33,10 +33,6 @@ shadcn/ui now ships first-class versions of several components that ui-x origina
 
 The final Radix-based sources remain available under the [`radix`](https://github.com/junwen-k/ui-x/tree/radix) tag.
 
-### Thank you
-
-To everyone who has used ui-x, filed issues and contributed — thank you. This is the biggest update the project has had, and it wouldn't have happened without you 🙏
-
 ## June 2025 - Phone Input and Emoji Picker
 
 We've added a new `<PhoneInput />` component and a new `<EmojiPicker />` component.

--- a/apps/v4/content/docs/changelog.mdx
+++ b/apps/v4/content/docs/changelog.mdx
@@ -3,6 +3,40 @@ title: Changelog
 description: Latest updates and announcements.
 ---
 
+## July 2026 - Base UI
+
+ui-x is now built on [Base UI](https://base-ui.com). Following shadcn/ui's adoption of Base UI as the modern successor to Radix UI, every component has been rebuilt on Base UI primitives and restyled to match the latest shadcn/ui design.
+
+<ComponentPreview name="date-picker-demo" />
+
+### What's changed
+
+- **Base UI everywhere** — All Radix UI dependencies are gone. Components are built on Base UI primitives and utilities, with React 19 ref handling throughout.
+- **Restyled** — Every component, demo and docs page has been refreshed against the latest shadcn/ui styling.
+- **Simpler forms** — Demos use Base UI's `Field` and `Form` for form plumbing. For React Hook Form or TanStack Form wiring, see the shadcn/ui [forms guides](https://ui.shadcn.com/docs/forms).
+
+### Superseded components
+
+shadcn/ui now ships first-class versions of several components that ui-x originally existed to fill in. These have been removed in favor of the official ones:
+
+| ui-x component | Use instead                                                          |
+| -------------- | -------------------------------------------------------------------- |
+| Calendar       | [Calendar](https://ui.shadcn.com/docs/components/calendar)           |
+| Combobox       | [Combobox](https://ui.shadcn.com/docs/components/combobox)           |
+| Control Group  | [Button Group](https://ui.shadcn.com/docs/components/button-group)   |
+| File List      | [Attachment](https://ui.shadcn.com/docs/components/attachment)       |
+| Input Base     | [Input Group](https://ui.shadcn.com/docs/components/input-group)     |
+| Kbd            | [Kbd](https://ui.shadcn.com/docs/components/kbd)                     |
+| Native Select  | [Native Select](https://ui.shadcn.com/docs/components/native-select) |
+
+### Looking for the Radix version?
+
+The final Radix-based sources remain available under the [`radix`](https://github.com/junwen-k/ui-x/tree/radix) tag.
+
+### Thank you
+
+To everyone who has used ui-x, filed issues and contributed — thank you. This is the biggest update the project has had, and it wouldn't have happened without you 🙏
+
 ## June 2025 - Phone Input and Emoji Picker
 
 We've added a new `<PhoneInput />` component and a new `<EmojiPicker />` component.


### PR DESCRIPTION
## Summary

The ship changelog entry, written as a single announcement per the roadmap (no piecemeal entries):

- **Base UI as Radix's modern successor** — headline framing, matching shadcn/ui's direction.
- **The nova restyle** — components, demos and docs refreshed against latest shadcn/ui.
- **Superseded components table** — the 7 removals with links to their official shadcn/ui replacements.
- **`#radix` tag pointer** — where the final Radix-based sources live.

Verified rendering on the dev server: preview renders, table shows all 7 rows, links present.

Note: the `radix` tag link will 404 until the tag is actually pushed at ship time — intentional, since this entry only goes live when `next` merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)