### PR TITLE
docs: surface llms.txt in the docs sidebar

### DIFF
--- a/apps/v4/content/docs/meta.json
+++ b/apps/v4/content/docs/meta.json
@@ -3,6 +3,7 @@
     "index",
     "installation",
     "changelog",
+    "[llms.txt](/llms.txt)",
     "primitives",
     "utilities",
     "components"


### PR DESCRIPTION
## Summary
- PR #78 shipped the `/llms.txt`, `/llms-full.txt`, and per-page `.md` routes plus the "Copy Page"/"Open in" control, but left the sidebar untouched
- Checked shadcn's actual source (`apps/v4/content/docs/(root)/meta.json` in shadcn-ui/ui) — they surface it with a single `"[llms.txt](/llms.txt)"` entry in `meta.json`'s `pages` array, not a custom component
- fumadocs-core's loader natively supports that `[Title](url)` syntax, turning it into a page-tree node without a real content file — so this is a one-line change that flows through the desktop sidebar, mobile nav, and command palette automatically, since they all read from the same tree

## Test plan
- [x] Verified in-browser: `llms.txt` appears in the "Sections" group of the desktop sidebar, right after Changelog
- [x] Verified in-browser: same link appears in the mobile nav sheet, for free
- [x] No component changes required or made

🤖 Generated with [Claude Code](https://claude.com/claude-code)