### PR TITLE
feat(docs): add sitemap and robots routes for the v4 site

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,10 +90,17 @@ only once the overhaul is finalized.
       kept frozen with a banner (see Guiding decisions); the banner went with
       it. The already-deployed `v3-ui-x` site is unaffected and keeps serving
       its last build.
-- [ ] Point canonical domain / SEO (sitemap, robots, `metadataBase`, og) at the
+- [x] Point canonical domain / SEO (sitemap, robots, `metadataBase`, og) at the
       v4 site. Simplified by the v3 removal: `v3-ui-x.junwen-k.dev` is already
       a separate domain/Vercel project, so no subdomain migration is needed —
-      just confirm `ui-x.junwen-k.dev` (v4) is the canonical/indexed one.
+      `ui-x.junwen-k.dev` (v4) was already the canonical/indexed one via
+      `metadataBase`/OG tags. Added the missing `sitemap.ts`/`robots.ts` pair —
+      shipped 2026-07-19. shadcn's own `apps/v4` has no precedent for these
+      (checked their repo and live site: neither `/robots.txt` nor
+      `/sitemap.xml` resolve), so built idiomatically instead: Next.js
+      `MetadataRoute.Sitemap`/`MetadataRoute.Robots`, with the sitemap walking
+      `source.getPages()` (same fumadocs page-tree approach as `llms.txt`) so
+      it can't drift from the sidebar.
 - [x] Update `installation.mdx` with registry install instructions and
       requirements. (`tailwind-v4.mdx` and the homepage "Introducing Tailwind
       v4" announcement badge removed 2026-07-15 — old news; the v3 pointer
@@ -375,3 +382,13 @@ out, e.g. accordion → "See the Base UI documentation").
   `docs/[[...slug]]/page.tsx` next to the title. Verified in-browser: all
   three routes resolve, the dropdown's four links (ChatGPT/Claude/Markdown/
   GitHub) point at the right URLs, copy re-uses the already-proven util.
+- **2026-07-19** — Closed the last open Phase 1 item: added `sitemap.ts` and
+  `robots.ts` (`apps/v4/src/app`). shadcn's own `apps/v4` has no equivalent
+  (verified against their repo and live site), so these were built idiomatic
+  Next.js-style instead — `MetadataRoute.Sitemap`/`MetadataRoute.Robots`, the
+  sitemap driven by `source.getPages()` so it walks the same fumadocs page
+  tree as `llms.txt` and can't drift from the sidebar. Verified locally: both
+  routes return 200, 29 URLs in the sitemap (home + 28 doc pages), no
+  duplicates. Phase 1 is now fully closed. Remaining before `next` → `main`:
+  just the merge itself (plus the 14 open Dependabot alerts on `main`, all
+  transitive/dev-tooling, triaged as non-blocking).

--- a/apps/v4/src/app/robots.ts
+++ b/apps/v4/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from "next";
+
+import { siteConfig } from "@/config/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+  };
+}

--- a/apps/v4/src/app/sitemap.ts
+++ b/apps/v4/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from "next";
+
+import { siteConfig } from "@/config/site";
+import { source } from "@/lib/source";
+
+export const revalidate = false;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = source.getPages().map((page) => ({
+    url: `${siteConfig.url}${page.url}`,
+    changeFrequency: "weekly" as const,
+  }));
+
+  return [
+    {
+      url: siteConfig.url,
+      changeFrequency: "monthly",
+    },
+    ...docs,
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `apps/v4/src/app/sitemap.ts` and `robots.ts`, closing the last open Phase 1 item in `ROADMAP.md` (canonical domain / SEO).
- `metadataBase`/OG tags were already pointed at `ui-x.junwen-k.dev`; this was the missing piece.
- Checked shadcn's own `apps/v4` for a pattern to mirror — they don't ship either file (confirmed against their GitHub repo and live site: neither `/robots.txt` nor `/sitemap.xml` resolve on `ui.shadcn.com`). Built these idiomatically instead, using Next.js's `MetadataRoute.Sitemap`/`MetadataRoute.Robots` conventions.
- The sitemap is driven by `source.getPages()`, the same fumadocs page-tree API used by the existing `llms.txt` route, so it walks the live sidebar rather than a hand-maintained list.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors, same 7 pre-existing warnings in unrelated files
- [x] Verified locally: `/robots.txt` and `/sitemap.xml` both return 200; sitemap lists 29 URLs (home + 28 doc pages) with no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)