### PR TITLE
fix(ci): pin Vercel's pnpm to the packageManager field via corepack

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## Problem

The `next` Vercel deploys intermittently fail at install with:

```
Using pnpm@9.x based on project creation date
ENOENT: no such file or directory, open '/vercel/path0/.pnpm-store/v3/files/…-index.json'
Error: Command "pnpm install" exited with 254
```

**Root cause is pnpm version drift, not the cache.** `pnpm-lock.yaml` is `lockfileVersion: 9.0`, which pnpm 9 *or* 10 can produce; Vercel's auto-detection resolves an old project like this one to **pnpm 9**, against the repo's `pnpm@10.34.5` pin. Builds run pnpm 9, leaving the content-addressable store inconsistent, and a later cache restore trips over the half-written store index. Past one-off cache clears didn't stick because the clean rebuild still ran pnpm 9 and re-poisoned the cache.

## Fix

Override the install command to invoke corepack, which reads the version from `package.json`'s `packageManager` field:

```json
{ "installCommand": "corepack pnpm install --frozen-lockfile" }
```

- **Single source of truth** — the version comes from `packageManager`; bump it there and the deploy follows. Nothing to keep in sync.
- Explicit `corepack` invocation, not a bare `pnpm install` override — the latter would drop to pnpm 6 ("oldest version available", per Vercel docs).
- Makes the `ENABLE_EXPERIMENTAL_COREPACK` env var redundant (harmless to leave).

## One-time step after merge

The currently-cached pnpm-9 store is still poisoned, so a single **no-cache** redeploy is needed to flush it (Deployments → ⋯ → Redeploy → uncheck "Use existing Build Cache"). After that, every build uses pnpm 10 and the cache stays coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)