### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Licensed under the [MIT license](https://github.com/junwen-k/ui-x/blob/main/LICE
 
 Your support means a lot to us - if you find junwen-k/ui-x helpful, please consider giving it a star! ⭐
 
-<a href="https://star-history.com/#junwen-k/ui-x&Date">
+<a href="https://star-history.dera.page/#junwen-k/ui-x&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=junwen-k/ui-x&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=junwen-k/ui-x&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=junwen-k/ui-x&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=junwen-k/ui-x&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=junwen-k/ui-x&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=junwen-k/ui-x&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The Star History chart in the README is currently broken because it depends on GitHub's stargazer API, which now restricts access. This switches the chart to star-history.dera.page, an alternative that uses a different data source requiring no API token, so the chart renders again for anyone landing on the repo.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>